### PR TITLE
[WIP] Make usage of another Association class in ApplicationEntity easier

### DIFF
--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -169,6 +169,7 @@ class ApplicationEntity(object):
         self.address = platform.node()
         self.port = port
         self.ae_title = ae_title
+        self.ASSOCIATION = Association
 
         # Avoid dangerous default values
         if transfer_syntax is None:
@@ -344,7 +345,7 @@ class ApplicationEntity(object):
 
             # Create a new Association
             # Association(local_ae, local_socket=None, max_pdu=16382)
-            assoc = Association(self,
+            assoc = self.ASSOCIATION(self,
                                 client_socket,
                                 max_pdu=self.maximum_pdu_size,
                                 acse_timeout=self.acse_timeout,
@@ -422,7 +423,7 @@ class ApplicationEntity(object):
                    'Port' : port}
 
         # Associate
-        assoc = Association(local_ae=self,
+        assoc = self.ASSOCIATION(local_ae=self,
                             peer_ae=peer_ae,
                             acse_timeout=self.acse_timeout,
                             dimse_timeout=self.dimse_timeout,

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -141,6 +141,16 @@ class ApplicationEntity(object):
     transfer_syntaxes : List of pydicom.uid.UID
         The supported transfer syntaxes
     """
+
+    """Association class type is set to a variable to make usage of another
+    maybe overidden type of Association easier
+    Example:
+        class MyApplicationEntity(ApplicationEntity):
+            ASSOCIATION = MyAssociation
+    """
+    ASSOCIATION = Association
+
+
     # pylint: disable=too-many-instance-attributes,too-many-public-methods
     def __init__(self, ae_title='PYNETDICOM', port=0, scu_sop_class=None,
                  scp_sop_class=None, transfer_syntax=None):
@@ -169,7 +179,6 @@ class ApplicationEntity(object):
         self.address = platform.node()
         self.port = port
         self.ae_title = ae_title
-        self.ASSOCIATION = Association
 
         # Avoid dangerous default values
         if transfer_syntax is None:

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -142,12 +142,12 @@ class ApplicationEntity(object):
         The supported transfer syntaxes
     """
 
-    """Association class type is set to a variable to make usage of another
-    maybe overidden type of Association easier
-    Example:
-        class MyApplicationEntity(ApplicationEntity):
-            ASSOCIATION = MyAssociation
-    """
+    # Association class type is set to a variable to make usage of another
+    # maybe overidden type of Association easier
+    # Example:
+    #     class MyApplicationEntity(ApplicationEntity):
+    #         ASSOCIATION = MyAssociation
+    #
     ASSOCIATION = Association
 
 
@@ -355,10 +355,10 @@ class ApplicationEntity(object):
             # Create a new Association
             # Association(local_ae, local_socket=None, max_pdu=16382)
             assoc = self.ASSOCIATION(self,
-                                client_socket,
-                                max_pdu=self.maximum_pdu_size,
-                                acse_timeout=self.acse_timeout,
-                                dimse_timeout=self.dimse_timeout)
+                                     client_socket,
+                                     max_pdu=self.maximum_pdu_size,
+                                     acse_timeout=self.acse_timeout,
+                                     dimse_timeout=self.dimse_timeout)
             assoc.start()
             self.active_associations.append(assoc)
 
@@ -433,11 +433,11 @@ class ApplicationEntity(object):
 
         # Associate
         assoc = self.ASSOCIATION(local_ae=self,
-                            peer_ae=peer_ae,
-                            acse_timeout=self.acse_timeout,
-                            dimse_timeout=self.dimse_timeout,
-                            max_pdu=max_pdu,
-                            ext_neg=ext_neg)
+                                 peer_ae=peer_ae,
+                                 acse_timeout=self.acse_timeout,
+                                 dimse_timeout=self.dimse_timeout,
+                                 max_pdu=max_pdu,
+                                 ext_neg=ext_neg)
         assoc.start()
 
         # Endlessly loops while the Association negotiation is taking place


### PR DESCRIPTION
This is a small change if we want to use another Association class in ApplicationEntity.
 
It could be an overridden version of the current Association class.

E.g.

```python
class MyAssociation(Association):
    pass

ae = AE()
ae.ASSOCIATION = MyAssociation
ae.start()
```