### PR TITLE
[WIP] Split CheckRelease in receiving A-RELEASE req and sending A-RELEASE confirmation

### DIFF
--- a/pynetdicom3/acse.py
+++ b/pynetdicom3/acse.py
@@ -364,8 +364,7 @@ class ACSEServiceProvider(object):
         self.dul.send_pdu(primitive)
 
     def CheckRelease(self):
-        """Checks for release request from the remote AE. Upon reception of
-        the request a confirmation is sent"""
+        """Checks for release request from the remote AE."""
         rel = self.dul.peek_next_pdu()
         if rel.__class__ == A_RELEASE:
             # Make sure this is a A-RELEASE request primitive
@@ -373,13 +372,15 @@ class ACSEServiceProvider(object):
                 return False
 
             self.dul.receive_pdu(wait=False)
-            release_rsp = A_RELEASE()
-            release_rsp.result = "affirmative"
-            self.dul.send_pdu(release_rsp)
-
             return True
         else:
             return False
+
+    def Release(self):
+        """Upon reception of the request a confirmation is sent"""
+        release_rsp = A_RELEASE()
+        release_rsp.result = "affirmative"
+        self.dul.send_pdu(release_rsp)
 
     def CheckAbort(self):
         """Checks for abort indication from the remote AE. """

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -494,6 +494,7 @@ class Association(threading.Thread):
                 # Callback trigger
                 self.debug_association_released()
                 self.ae.on_association_released()
+                self.acse.Release()
                 self.kill()
 
             # Check for abort
@@ -586,6 +587,7 @@ class Association(threading.Thread):
                         # Callback trigger
                         self.ae.on_association_released()
                         self.debug_association_released()
+                        self.acse.Release()
                         self.kill()
                         return
 


### PR DESCRIPTION
Current implementation of ```CheckRelease()``` either **checks** and **releases** the current association. As a result the usage of callback ```on_association_released``` is more or less useless because the association is already released.

Supposing that on this callback someone could implement a procedure that could fail (eg writing to a file) the user should have the opportunity to abort the association instead of sending a release confirmation primitive. 

This PR lets the user abort an association within the ```on_association_released``` callback.