### PR TITLE
Adding support for N-SET and N-CREATE for MPPS SCP

### DIFF
--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -1257,12 +1257,67 @@ class ApplicationEntity(object):
                                   "AE.on_n_get function prior to calling "
                                   "AE.start()")
 
-    def on_n_set(self):
+    def on_n_set(self, dataset):
         """Callback for when a N-SET is received.
+
+        Must be defined by the user prior to calling AE.start() and must return
+        either an int or a pydicom Dataset containing a (0000,0900) Status
+        element with a valid N-SET status value.
+
+        Called by the corresponding pynetdicom3.sop_class Service Class' SCP()
+        method after receiving a N-SET request and prior to sending the
+        response.
+
+        Supported Service Classes
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        Modality Performed Procedure Step SOP Class
+
+        Status
+        ------
+        Success
+
+        - 0x0000 - Success
+
+        Failure
+
+        - 0x0117 - Invalid SOP instance
+        - 0x0122 - SOP class not supported
+        - 0x0124 - Not authorised
+        - 0x0210 - Duplicate invocation
+        - 0x0211 - Unrecognised operation
+        - 0x0212 - Mistyped argument
+        - FIXME: add all of them
+
+        Parameters
+        ----------
+        dataset : pydicom.dataset.Dataset
+            The DICOM dataset sent by the peer in the N-SET request.
+
+        Returns
+        -------
+        status : pydicom.dataset.Dataset or int
+            The status returned to the peer AE in the N-SET response. Must be
+            a valid N-SET status value for the applicable Service Class as
+            either an int or a Dataset object containing (at a minimum) a
+            (0000,0900) 'Status' element. If returning a Dataset object then it
+            may also contain optional elements related to the Status (as in the
+            DICOM Standard Part 7, Annex C).
+
+        Raises
+        ------
+        NotImplementedError
+            If the callback has not been implemented by the user
+
+        See Also
+        --------
+        association.Association.send_n_set
+        dimse_primitives.N_SET
+        sop_class.ModalityPerformedProcedureStepSOPClass
 
         References
         ----------
-        DICOM Standard Part 4, Annexes F, H, CC and DD
+        DICOM Standard Part 4, Annexes F.7, H, CC and DD
+        DICOM Standard Part 7, Section 10.1.3
         """
         raise NotImplementedError("User must implement the "
                                   "AE.on_n_set function prior to calling "
@@ -1279,12 +1334,67 @@ class ApplicationEntity(object):
                                   "AE.on_n_action function prior to calling "
                                   "AE.start()")
 
-    def on_n_create(self):
+    def on_n_create(self, dataset):
         """Callback for when a N-CREATE is received.
+
+        Must be defined by the user prior to calling AE.start() and must return
+        either an int or a pydicom Dataset containing a (0000,0900) Status
+        element with a valid N-CREATE status value.
+
+        Called by the corresponding pynetdicom3.sop_class Service Class' SCP()
+        method after receiving a N-CREATE request and prior to sending the
+        response.
+
+        Supported Service Classes
+        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        Modality Performed Procedure Step SOP Class
+
+        Status
+        ------
+        Success
+
+        - 0x0000 - Success
+
+        Failure
+
+        - 0x0117 - Invalid SOP instance
+        - 0x0122 - SOP class not supported
+        - 0x0124 - Not authorised
+        - 0x0210 - Duplicate invocation
+        - 0x0211 - Unrecognised operation
+        - 0x0212 - Mistyped argument
+        - FIXME: add all of them
+
+        Parameters
+        ----------
+        dataset : pydicom.dataset.Dataset
+            The DICOM dataset sent by the peer in the N-CREATE request.
+
+        Returns
+        -------
+        status : pydicom.dataset.Dataset or int
+            The status returned to the peer AE in the N-CREATE response. Must be
+            a valid N-CREATE status value for the applicable Service Class as
+            either an int or a Dataset object containing (at a minimum) a
+            (0000,0900) 'Status' element. If returning a Dataset object then it
+            may also contain optional elements related to the Status (as in the
+            DICOM Standard Part 7, Annex C).
+
+        Raises
+        ------
+        NotImplementedError
+            If the callback has not been implemented by the user
+
+        See Also
+        --------
+        association.Association.send_n_create
+        dimse_primitives.N_CREATE
+        sop_class.ModalityPerformedProcedureStepSOPClass
 
         References
         ----------
-        DICOM Standard Part 4, Annexes F, H, R, S, CC and DD
+        DICOM Standard Part 4, Annexes F.7, H, R, S, CC and DD
+        DICOM Standard Part 7, Section 10.1.5
         """
         raise NotImplementedError("User must implement the "
                                   "AE.on_n_create function prior to calling "

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -1257,7 +1257,7 @@ class ApplicationEntity(object):
                                   "AE.on_n_get function prior to calling "
                                   "AE.start()")
 
-    def on_n_set(self, dataset):
+    def on_n_set(self, dataset, sop_class, sop_instance_uid):
         """Callback for when a N-SET is received.
 
         Must be defined by the user prior to calling AE.start() and must return
@@ -1292,6 +1292,14 @@ class ApplicationEntity(object):
         ----------
         dataset : pydicom.dataset.Dataset
             The DICOM dataset sent by the peer in the N-SET request.
+
+        sop_class : sop_class.ServiceClass subclass. This is the SOP-class
+            which handled the message and called us, contains information
+            about the assocation, s.a. the remote AET and the current Abstract
+            Context.
+
+        sop_instance_uid : the SOPInstanceUID the request referred to, i.e the
+            one that should be updated by this N-SET command.
 
         Returns
         -------
@@ -1334,7 +1342,7 @@ class ApplicationEntity(object):
                                   "AE.on_n_action function prior to calling "
                                   "AE.start()")
 
-    def on_n_create(self, dataset):
+    def on_n_create(self, dataset, sop_class, sop_instance_uid):
         """Callback for when a N-CREATE is received.
 
         Must be defined by the user prior to calling AE.start() and must return
@@ -1379,6 +1387,14 @@ class ApplicationEntity(object):
             (0000,0900) 'Status' element. If returning a Dataset object then it
             may also contain optional elements related to the Status (as in the
             DICOM Standard Part 7, Annex C).
+
+        sop_class : sop_class.ServiceClass subclass. This is the SOP-class
+            which handled the message and called us, contains information
+            about the assocation, s.a. the remote AET and the current Abstract
+            Context.
+
+        sop_instance_uid : the SOPInstanceUID the request referred to, i.e the
+            one that should be created by this N-CREATE command.
 
         Raises
         ------

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -455,15 +455,20 @@ class Association(threading.Thread):
 
             # DIMSE message received
             if msg:
-                # Use the Message's Affected SOP Class UID to create a new
-                #   SOP Class instance, if there's no AffectedSOPClassUID
-                #   then we received a C-CANCEL request
-                # FIXME
-                if not hasattr(msg, 'AffectedSOPClassUID'):
+                # Use the Message's Affected SOP Class UID, or conversely
+                # Requested SOP Class UID, to create a new SOP Class instance.
+                # If there's no AffectedSOPClassUID then we received a C-CANCEL
+                # request.
+                if hasattr(msg, 'AffectedSOPClassUID') and msg.AffectedSOPClassUID:
+                    sop_class = uid_to_sop_class(msg.AffectedSOPClassUID)()
+                elif hasattr(msg, 'RequestedSOPClassUID') and msg.RequestedSOPClassUID:
+                    sop_class = uid_to_sop_class(msg.RequestedSOPClassUID)()
+                else:
                     self.abort()
                     return
 
-                sop_class = uid_to_sop_class(msg.AffectedSOPClassUID)()
+                # TODO: check that whether we have AffectedSOPClassUID or
+                # RequestedSOPClassUID matches the action.
 
                 # Check that the SOP Class is supported by the AE
                 # New method

--- a/pynetdicom3/dimse_messages.py
+++ b/pynetdicom3/dimse_messages.py
@@ -458,10 +458,13 @@ class DIMSEMessage(object):
         elif cls_type_name == 'N_EVENT_REPORT_RSP':
             self.data_set = primitive.EventReply
             self.command_set.CommandDataSetType = 0x0001
-        elif cls_type_name in ['N_GET_RSP', 'N_SET_RSP',
-                               'N_CREATE_RQ', 'N_CREATE_RSP']:
+        elif cls_type_name == 'N_CREATE_RQ':
             self.data_set = primitive.AttributeList
             self.command_set.CommandDataSetType = 0x0001
+        elif cls_type_name in ['N_GET_RSP', 'N_SET_RSP', 'N_CREATE_RSP']:
+            if primitive.AttributeList:
+                self.data_set = primitive.AttributeList
+                self.command_set.CommandDataSetType = 0x0001
         elif cls_type_name == 'N_SET_RQ':
             self.data_set = primitive.ModificationList
             self.command_set.CommandDataSetType = 0x0001

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -1423,11 +1423,13 @@ class NCreateSetServiceClass(ServiceClass):
         # Build appropriate response primitive
         if isinstance(msg, N_CREATE):
             rsp = N_CREATE()
+            rsp.AffectedSOPClassUID = msg.AffectedSOPClassUID
+            rsp.AffectedSOPInstanceUID = msg.AffectedSOPInstanceUID
         elif isinstance(msg, N_SET):
             rsp = N_SET()
+            rsp.RequestedSOPClassUID = msg.RequestedSOPClassUID
+            rsp.RequestedSOPInstanceUID = msg.RequestedSOPInstanceUID
         rsp.MessageIDBeingRespondedTo = msg.MessageID
-        rsp.AffectedSOPClassUID = msg.AffectedSOPClassUID
-        rsp.AffectedSOPInstanceUID = msg.AffectedSOPClassUID
         rsp = self.validate_status(0x0000, rsp)
 
         # Try and run the user on_c_echo callback

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -1432,11 +1432,11 @@ class NCreateSetServiceClass(ServiceClass):
         if is_create:
             rsp = N_CREATE()
             rsp.AffectedSOPClassUID = msg.AffectedSOPClassUID
-            rsp.AffectedSOPInstanceUID = msg.AffectedSOPInstanceUID
+            sop_instance_uid = rsp.AffectedSOPInstanceUID = msg.AffectedSOPInstanceUID
         else:
             rsp = N_SET()
             rsp.RequestedSOPClassUID = msg.RequestedSOPClassUID
-            rsp.RequestedSOPInstanceUID = msg.RequestedSOPInstanceUID
+            sop_instance_uid = rsp.RequestedSOPInstanceUID = msg.RequestedSOPInstanceUID
         rsp.MessageIDBeingRespondedTo = msg.MessageID
         rsp = self.validate_status(0x0000, rsp)
 
@@ -1459,9 +1459,9 @@ class NCreateSetServiceClass(ServiceClass):
         # Try and run the user on_n_create/set callback
         try:
             if is_create:
-                status = self.AE.on_n_create(dataset)
+                status = self.AE.on_n_create(dataset, self, sop_instance_uid)
             else:
-                status = self.AE.on_n_set(dataset)
+                status = self.AE.on_n_set(dataset, self, sop_instance_uid)
         except:
             LOGGER.exception("Exception in the AE.on_n_create/set() callback")
             # Failure: Processing Failure - a general failure in processing

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -1459,13 +1459,18 @@ class NCreateSetServiceClass(ServiceClass):
         # Try and run the user on_n_create/set callback
         try:
             if is_create:
-                self.AE.on_n_create(dataset)
+                status = self.AE.on_n_create(dataset)
             else:
-                self.AE.on_n_set(dataset)
+                status = self.AE.on_n_set(dataset)
         except:
             LOGGER.exception("Exception in the AE.on_n_create/set() callback")
+            # Failure: Processing Failure - a general failure in processing
+            #   the operation was encountered.
+            rsp = self.validate_status(0x0110, rsp)
+            self.DIMSE.send_msg(rsp, self.pcid)
+            return
 
-        # Send primitive
+        rsp = self.validate_status(status, rsp)
         self.DIMSE.send_msg(rsp, self.pcid)
 
 

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -249,7 +249,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_n_set(None)
+            ae.on_n_set(None, None, None)
 
     def test_on_n_action(self):
         """Test default callback raises exception"""
@@ -261,7 +261,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_n_create(None)
+            ae.on_n_create(None, None, None)
 
     def test_on_n_delete(self):
         """Test default callback raises exception"""

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -249,7 +249,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_n_set()
+            ae.on_n_set(None)
 
     def test_on_n_action(self):
         """Test default callback raises exception"""
@@ -261,7 +261,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_n_create()
+            ae.on_n_create(None)
 
     def test_on_n_delete(self):
         """Test default callback raises exception"""


### PR DESCRIPTION
Supports accepting these messages, passing them on to callbacks, currently always sending an OK response (ignoring status returned from callback).