### PR TITLE
Pass called SOPClass to on_c_cmd callbacks

### DIFF
--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -810,7 +810,7 @@ class ApplicationEntity(object):
 
 
     # High-level DIMSE-C callbacks - user should implement these as required
-    def on_c_echo(self):
+    def on_c_echo(self, sop_class):
         """Callback for when a C-ECHO request is received.
 
         User implementation is not required for the C-ECHO service, but if you
@@ -843,6 +843,11 @@ class ApplicationEntity(object):
         - 0x0212 - Mistyped argument
         - 0x0211 - Unrecognised operation
 
+        Parameters
+        ----------
+        sop_class : sop_class.ServiceClass (subclass)
+            The DICOM SOPClass requested for this C-FIND command.
+
         Returns
         -------
         status : pydicom.dataset.Dataset or int
@@ -867,7 +872,7 @@ class ApplicationEntity(object):
         # User implementation of on_c_echo is optional
         return 0x0000
 
-    def on_c_store(self, dataset):
+    def on_c_store(self, dataset, sop_class):
         """Callback for when a C-STORE request is received.
 
         Must be defined by the user prior to calling AE.start() and must return
@@ -914,6 +919,10 @@ class ApplicationEntity(object):
         ----------
         dataset : pydicom.dataset.Dataset
             The DICOM dataset sent by the peer in the C-STORE request.
+        sop_class : sop_class.ServiceClass (subclass)
+            The DICOM SOPClass requested for this C-STORE command.
+            This can also be None, if the store request was initiated by
+            a C-MOVE or C-GET.
 
         Returns
         -------
@@ -1041,7 +1050,7 @@ class ApplicationEntity(object):
                                   "AE.on_c_find_cancel function prior to "
                                   "calling AE.start()")
 
-    def on_c_get(self, dataset):
+    def on_c_get(self, dataset, sop_class):
         """Callback for when a C-GET request is received.
 
         Must be defined by the user prior to calling AE.start() and must yield
@@ -1082,6 +1091,8 @@ class ApplicationEntity(object):
         ----------
         dataset : pydicom.dataset.Dataset
             The DICOM Identifier dataset sent by the peer in the C-GET request.
+        sop_class : sop_class.ServiceClass (subclass)
+            The DICOM SOPClass requested for this C-GET command.
 
         Yields
         ------
@@ -1130,7 +1141,7 @@ class ApplicationEntity(object):
                                   "AE.on_c_get_cancel function prior to "
                                   "calling AE.start()")
 
-    def on_c_move(self, dataset, move_aet):
+    def on_c_move(self, dataset, move_aet, sop_class):
         """Callback for when a C-MOVE request is received.
 
         Must be defined by the user prior to calling AE.start().
@@ -1183,6 +1194,8 @@ class ApplicationEntity(object):
             The destination AE title that matching SOP Instances will be sent
             to using C-STORE sub-operations. `move_aet` will be a correctly
             formatted AE title (16 chars, with trailing spaces as padding).
+        sop_class : sop_class.ServiceClass (subclass)
+            The DICOM SOPClass requested for this C-MOVE command.
 
         Yields
         ------

--- a/pynetdicom3/applicationentity.py
+++ b/pynetdicom3/applicationentity.py
@@ -945,7 +945,7 @@ class ApplicationEntity(object):
         raise NotImplementedError("User must implement the AE.on_c_store "
                                   "function prior to calling AE.start()")
 
-    def on_c_find(self, dataset):
+    def on_c_find(self, dataset, sop_class):
         """Callback for when a C-FIND request is received.
 
         Must be defined by the user prior to calling AE.start() and must yield
@@ -990,6 +990,9 @@ class ApplicationEntity(object):
         dataset : pydicom.dataset.Dataset
             The DICOM Identifier dataset sent by the peer in the C-FIND
             request.
+
+        sop_class : sop_class.ServiceClass (subclass)
+            The DICOM SOPClass requested for this C-FIND command.
 
         Yields
         ------

--- a/pynetdicom3/apps/echoscp/echoscp.py
+++ b/pynetdicom3/apps/echoscp/echoscp.py
@@ -184,7 +184,7 @@ if args.prefer_big and ExplicitVRBigEndian in transfer_syntax:
     transfer_syntax.insert(0, ExplicitVRBigEndian)
 
 
-def on_c_echo():
+def on_c_echo(sop_class):
     """Optional implementation of the AE.on_c_echo callback."""
     # Return a Success response to the peer
     # We could also return a pydicom Dataset with a (0000, 0900) Status

--- a/pynetdicom3/apps/findscp/findscp.py
+++ b/pynetdicom3/apps/findscp/findscp.py
@@ -151,7 +151,7 @@ if args.prefer_big and ExplicitVRBigEndian in transfer_syntax:
         transfer_syntax.insert(0, ExplicitVRBigEndian)
 
 
-def on_c_find(dataset):
+def on_c_find(dataset, sop_class):
     """Implement the ae.on_c_find callback."""
     basedir = '../../tests/dicom_files/'
     dcm_files = ['RTImageStorage.dcm']

--- a/pynetdicom3/apps/getscp/getscp.py
+++ b/pynetdicom3/apps/getscp/getscp.py
@@ -150,7 +150,7 @@ if args.prefer_big and ExplicitVRBigEndian in transfer_syntax:
         transfer_syntax.remove(ExplicitVRBigEndian)
         transfer_syntax.insert(0, ExplicitVRBigEndian)
 
-def on_c_get(dataset):
+def on_c_get(dataset, sop_class):
     """Implement the on_c_get callback"""
     basedir = '../../tests/dicom_files/'
     dcm_files = ['RTImageStorage.dcm']

--- a/pynetdicom3/apps/movescp/movescp.py
+++ b/pynetdicom3/apps/movescp/movescp.py
@@ -150,7 +150,7 @@ if args.prefer_big and ExplicitVRBigEndian in transfer_syntax:
         transfer_syntax.remove(ExplicitVRBigEndian)
         transfer_syntax.insert(0, ExplicitVRBigEndian)
 
-def on_c_move(dataset, move_aet):
+def on_c_move(dataset, move_aet, sop_class):
     """Implement the on_c_move callback"""
     basedir = '../../tests/dicom_files/'
     dcm_files = ['RTImageStorage.dcm']

--- a/pynetdicom3/apps/storescp/storescp.py
+++ b/pynetdicom3/apps/storescp/storescp.py
@@ -183,7 +183,7 @@ if args.prefer_big and ExplicitVRBigEndian in transfer_syntax:
         transfer_syntax.remove(ExplicitVRBigEndian)
         transfer_syntax.insert(0, ExplicitVRBigEndian)
 
-def on_c_store(dataset):
+def on_c_store(dataset, sop_class):
     """
     Write `dataset` to file as little endian implicit VR
 

--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -1758,7 +1758,7 @@ class Association(threading.Thread):
 
         #  Attempt to run the ApplicationEntity's on_c_store callback
         try:
-            status = self.ae.on_c_store(ds)
+            status = self.ae.on_c_store(ds, None)
         except Exception as ex:
             LOGGER.error("Exception in the "
                          "ApplicationEntity.on_c_store() callback")

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -499,7 +499,7 @@ class QueryRetrieveFindServiceClass(ServiceClass):
         def wrap_on_c_find():
             try:
                 # We unpack here so that the error is still caught
-                for val1, val2 in self.AE.on_c_find(identifier):
+                for val1, val2 in self.AE.on_c_find(identifier, self):
                     yield val1, val2
             except Exception:
                 # TODO: special (singleton) value

--- a/pynetdicom3/sop_class.py
+++ b/pynetdicom3/sop_class.py
@@ -228,7 +228,7 @@ class VerificationServiceClass(ServiceClass):
         #   the Status as either an int or Dataset, and any failures in the
         #   callback results in 0x0000 'Success'
         try:
-            status = self.AE.on_c_echo()
+            status = self.AE.on_c_echo(self)
             if isinstance(status, Dataset):
                 if 'Status' not in status:
                     raise AttributeError("The 'status' dataset returned by "
@@ -351,7 +351,7 @@ class StorageServiceClass(ServiceClass):
 
         # Attempt to run the ApplicationEntity's on_c_store callback
         try:
-            rsp_status = self.AE.on_c_store(ds)
+            rsp_status = self.AE.on_c_store(ds, self)
         except Exception as ex:
             LOGGER.error("Exception in the ApplicationEntity.on_c_store() "
                          "callback")
@@ -736,7 +736,7 @@ class QueryRetrieveMoveServiceClass(ServiceClass):
         # Callback - C-MOVE
         try:
             # yields (addr, port), int, (status, dataset), ...
-            result = self.AE.on_c_move(identifier, req.MoveDestination)
+            result = self.AE.on_c_move(identifier, req.MoveDestination, self)
         except Exception as ex:
             LOGGER.error("Exception in user's on_c_move implementation.")
             LOGGER.exception(ex)
@@ -1149,7 +1149,7 @@ class QueryRetrieveGetServiceClass(ServiceClass):
         # Callback - C-GET
         try:
             # yields int, (status, dataset), ...
-            result = self.AE.on_c_get(identifier)
+            result = self.AE.on_c_get(identifier, self)
         except Exception as ex:
             LOGGER.error("Exception in user's on_c_get implementation.")
             LOGGER.exception(ex)

--- a/pynetdicom3/tests/dummy_c_scp.py
+++ b/pynetdicom3/tests/dummy_c_scp.py
@@ -78,7 +78,7 @@ class DummyBaseSCP(threading.Thread):
         """Callback for ae.on_c_store"""
         raise RuntimeError("You should not have been able to get here.")
 
-    def on_c_find(self, ds):
+    def on_c_find(self, ds, sopclass):
         """Callback for ae.on_c_find"""
         raise RuntimeError("You should not have been able to get here.")
 
@@ -161,7 +161,7 @@ class DummyFindSCP(DummyBaseSCP):
         self.identifiers = [identifier]
         self.cancel = False
 
-    def on_c_find(self, ds):
+    def on_c_find(self, ds, sop_class):
         """Callback for ae.on_c_find"""
         time.sleep(self.delay)
 

--- a/pynetdicom3/tests/dummy_c_scp.py
+++ b/pynetdicom3/tests/dummy_c_scp.py
@@ -70,15 +70,15 @@ class DummyBaseSCP(threading.Thread):
         for assoc in self.ae.active_associations:
             assoc.release()
 
-    def on_c_echo(self):
+    def on_c_echo(self, sop_class):
         """Callback for ae.on_c_echo"""
         raise RuntimeError("You should not have been able to get here.")
 
-    def on_c_store(self, ds):
+    def on_c_store(self, ds, sop_class):
         """Callback for ae.on_c_store"""
         raise RuntimeError("You should not have been able to get here.")
 
-    def on_c_find(self, ds, sopclass):
+    def on_c_find(self, ds, sop_class):
         """Callback for ae.on_c_find"""
         raise RuntimeError("You should not have been able to get here.")
 
@@ -86,7 +86,7 @@ class DummyBaseSCP(threading.Thread):
         """Callback for ae.on_c_cancel_find"""
         raise RuntimeError("You should not have been able to get here.")
 
-    def on_c_get(self, ds):
+    def on_c_get(self, ds, sop_class):
         """Callback for ae.on_c_get"""
         raise RuntimeError("You should not have been able to get here.")
 
@@ -94,7 +94,7 @@ class DummyBaseSCP(threading.Thread):
         """Callback for ae.on_c_cancel_get"""
         raise RuntimeError("You should not have been able to get here.")
 
-    def on_c_move(self, ds, move_aet):
+    def on_c_move(self, ds, move_aet, sop_class):
         """Callback for ae.on_c_move"""
         raise RuntimeError("You should not have been able to get here.")
 
@@ -110,7 +110,7 @@ class DummyVerificationSCP(DummyBaseSCP):
         DummyBaseSCP.__init__(self)
         self.status = 0x0000
 
-    def on_c_echo(self):
+    def on_c_echo(self, sop_class):
         """Callback for ae.on_c_echo
 
         Parameters
@@ -138,7 +138,7 @@ class DummyStorageSCP(DummyBaseSCP):
         self.status = 0x0000
         self.raise_exception = False
 
-    def on_c_store(self, ds):
+    def on_c_store(self, ds, sop_class):
         """Callback for ae.on_c_store"""
         time.sleep(self.delay)
         if self.raise_exception:
@@ -195,7 +195,7 @@ class DummyGetSCP(DummyBaseSCP):
         self.no_suboperations = 1
         self.cancel = False
 
-    def on_c_get(self, ds):
+    def on_c_get(self, ds, sop_class):
         """Callback for ae.on_c_get"""
         time.sleep(self.delay)
         ds = Dataset()
@@ -237,7 +237,7 @@ class DummyMoveSCP(DummyBaseSCP):
         self.test_no_yield = False
         self.test_no_subops = False
 
-    def on_c_move(self, ds, move_aet):
+    def on_c_move(self, ds, move_aet, sop_class):
         """Callback for ae.on_c_move"""
         time.sleep(self.delay)
         ds = Dataset()
@@ -259,7 +259,7 @@ class DummyMoveSCP(DummyBaseSCP):
                 return
             yield status, ds
 
-    def on_c_store(self, ds):
+    def on_c_store(self, ds, sop_class):
         return self.store_status
 
     def on_c_cancel_move(self):

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -201,7 +201,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_c_find(None)
+            ae.on_c_find(None, None)
 
     def test_on_c_find_cancel(self):
         """Test default callback raises exception"""

--- a/pynetdicom3/tests/test_ae.py
+++ b/pynetdicom3/tests/test_ae.py
@@ -189,13 +189,13 @@ class TestAEGoodCallbacks(unittest.TestCase):
     def test_on_c_echo(self):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
-        ae.on_c_echo()
+        ae.on_c_echo(None)
 
     def test_on_c_store(self):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_c_store(None)
+            ae.on_c_store(None, None)
 
     def test_on_c_find(self):
         """Test default callback raises exception"""
@@ -213,7 +213,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_c_get(None)
+            ae.on_c_get(None, None)
 
     def test_on_c_get_cancel(self):
         """Test default callback raises exception"""
@@ -225,7 +225,7 @@ class TestAEGoodCallbacks(unittest.TestCase):
         """Test default callback raises exception"""
         ae = AE(scu_sop_class=[VerificationSOPClass])
         with self.assertRaises(NotImplementedError):
-            ae.on_c_move(None, None)
+            ae.on_c_move(None, None, None)
 
     def test_on_c_move_cancel(self):
         """Test default callback raises exception"""

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -822,7 +822,7 @@ class TestAssociationSendCEcho(unittest.TestCase):
 
     def test_rsp_multi_status(self):
         """Test receiving a status with extra elements"""
-        def on_c_echo():
+        def on_c_echo(sop_class):
             ds = Dataset()
             ds.Status = 0x0122
             ds.ErrorComment = 'Some comment'
@@ -1420,7 +1420,7 @@ class TestAssociationSendCGet(unittest.TestCase):
         self.scp.statuses = [0xA701]
         self.scp.start()
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet])
-        def on_c_store(ds): return 0x0000
+        def on_c_store(ds, sop_class): return 0x0000
         assoc = ae.associate('localhost', 11112)
         self.assertTrue(assoc.is_established)
         for (status, ds) in assoc.send_c_get(self.ds, query_model='P'):
@@ -1435,7 +1435,7 @@ class TestAssociationSendCGet(unittest.TestCase):
         self.scp.statuses = [0xFF00, 0xFF00]
         self.scp.datasets = [self.good, self.good]
 
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             self.assertTrue('PatientName' in ds)
             return 0x0000
 
@@ -1471,7 +1471,7 @@ class TestAssociationSendCGet(unittest.TestCase):
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage],
                 scp_sop_class=[CTImageStorage])
-        def on_c_store(ds): return 0x0000
+        def on_c_store(ds, sop_class): return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
         self.assertTrue(assoc.is_established)
@@ -1500,7 +1500,7 @@ class TestAssociationSendCGet(unittest.TestCase):
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage],
                 scp_sop_class=[CTImageStorage])
-        def on_c_store(ds): return 0xA700
+        def on_c_store(ds, sop_class): return 0xA700
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
         self.assertTrue(assoc.is_established)
@@ -1529,7 +1529,7 @@ class TestAssociationSendCGet(unittest.TestCase):
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage],
                 scp_sop_class=[CTImageStorage])
-        def on_c_store(ds): return 0xB007
+        def on_c_store(ds, sop_class): return 0xB007
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
         self.assertTrue(assoc.is_established)
@@ -1573,7 +1573,7 @@ class TestAssociationSendCGet(unittest.TestCase):
                                CTImageStorage],
                 scp_sop_class=[CTImageStorage])
 
-        def on_c_store(ds): return 0xB007
+        def on_c_store(ds, sop_class): return 0xB007
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
         self.assertTrue(assoc.is_established)

--- a/pynetdicom3/tests/test_assoc.py
+++ b/pynetdicom3/tests/test_assoc.py
@@ -1240,7 +1240,7 @@ class TestAssociationSendCFind(unittest.TestCase):
         """Test bad dataset returned by on_c_find"""
         self.scp = DummyFindSCP()
 
-        def on_c_find(ds):
+        def on_c_find(ds, sop_class):
             def test(): pass
             yield 0xFF00, test
 

--- a/pynetdicom3/tests/test_sop.py
+++ b/pynetdicom3/tests/test_sop.py
@@ -591,7 +591,7 @@ class TestQRFindServiceClass(unittest.TestCase):
     def test_callback_exception(self):
         """Test SCP handles on_c_find yielding an exception"""
         self.scp = DummyFindSCP()
-        def on_c_find(ds): raise ValueError
+        def on_c_find(ds, sop_class): raise ValueError
         self.scp.ae.on_c_find = on_c_find
         self.scp.start()
 

--- a/pynetdicom3/tests/test_sop.py
+++ b/pynetdicom3/tests/test_sop.py
@@ -281,7 +281,7 @@ class TestVerificationServiceClass(unittest.TestCase):
     def test_scp_callback_exception(self):
         """Test on_c_echo raising an exception"""
         self.scp = DummyVerificationSCP()
-        def on_c_echo(): raise ValueError
+        def on_c_echo(sop_class): raise ValueError
         self.scp.ae.on_c_echo = on_c_echo
         self.scp.start()
 
@@ -419,7 +419,7 @@ class TestStorageServiceClass(unittest.TestCase):
     def test_scp_callback_exception(self):
         """Test on_c_store raising an exception"""
         self.scp = DummyStorageSCP()
-        def on_c_store(ds): raise ValueError
+        def on_c_store(ds, sop_class): raise ValueError
         self.scp.ae.on_c_store = on_c_store
         self.scp.start()
 
@@ -837,7 +837,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -861,7 +861,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -889,7 +889,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -916,7 +916,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -941,7 +941,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -962,7 +962,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -983,7 +983,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -999,13 +999,13 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_callback_exception(self):
         """Test SCP handles on_c_get yielding an exception"""
         self.scp = DummyGetSCP()
-        def on_c_get(ds): raise ValueError
+        def on_c_get(ds, sop_class): raise ValueError
         self.scp.ae.on_c_get = on_c_get
         self.scp.start()
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -1027,7 +1027,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -1047,7 +1047,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_callback_invalid_dataset(self):
         """Test status returned correctly if not yielding a Dataset."""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         self.scp.no_suboperations = 3
         self.scp.statuses = [Dataset(), Dataset(), Dataset(), 0x0000]
@@ -1093,7 +1093,7 @@ class TestQRGetServiceClass(unittest.TestCase):
 
         ae = AE(scu_sop_class=[PatientRootQueryRetrieveInformationModelGet,
                                CTImageStorage])
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         ae.on_c_store = on_c_store
         assoc = ae.associate('localhost', 11112)
@@ -1113,7 +1113,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_scp_basic(self):
         """Test on_c_get"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         self.scp.statuses = [0xFF00, 0xFF00]
         self.scp.datasets = [self.ds, self.ds]
@@ -1143,7 +1143,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_scp_store_failure(self):
         """Test when on_c_store returns failure status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xC001
         # SCP should override final success status
         self.scp.statuses = [0xFF00, 0xFF00, 0x0000]
@@ -1177,7 +1177,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_scp_store_warning(self):
         """Test when on_c_store returns warning status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xB000
         # SCP should override final success status
         self.scp.statuses = [0xFF00, 0xFF00, 0x0000]
@@ -1211,7 +1211,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_pending_success(self):
         """Test when on_c_get returns success status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         # SCP should override final warning status
         self.scp.statuses = [0xFF00, 0xB000]
@@ -1242,7 +1242,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_pending_warning(self):
         """Test when on_c_get returns warning status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xB000
         # SCP should override final success status
         self.scp.statuses = [0xFF00, 0x0000]
@@ -1273,7 +1273,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_pending_failure(self):
         """Test on_c_get returns warning status after store failure"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xC000
         # SCP should override final warning status
         self.scp.statuses = [0xFF00]
@@ -1304,7 +1304,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_multi_pending_success(self):
         """Test on_c_get returns success status after multi store success"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         # SCP should override final warning status
         self.scp.statuses = [0xFF00, 0xFF00, 0xFF00, 0xB000]
@@ -1341,7 +1341,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_multi_pending_warning(self):
         """Test on_c_get returns warning status after multi store warning"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xB000
         # SCP should override final warning status
         self.scp.statuses = [0xFF00, 0xFF00, 0xFF00, 0xB000]
@@ -1380,7 +1380,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_multi_pending_failure(self):
         """Test on_c_get returns warning status after multi store failure"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xC000
         # SCP should override final warning status
         self.scp.statuses = [0xFF00, 0xFF00, 0xFF00, 0xB000]
@@ -1419,7 +1419,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_failure(self):
         """Test when on_c_get returns failure status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         # SCP should override final success status
         self.scp.statuses = [0xFF00, 0xC000]
@@ -1450,7 +1450,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_success(self):
         """Test when on_c_get returns failure status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         # SCP should override final success status
         self.scp.statuses = [0xFF00]
@@ -1481,7 +1481,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_cancel(self):
         """Test on_c_get returns cancel status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0x0000
         # SCP should override final success status
         self.scp.statuses = [0xFF00, 0xFE00, 0x0000]
@@ -1512,7 +1512,7 @@ class TestQRGetServiceClass(unittest.TestCase):
     def test_get_warning(self):
         """Test on_c_get returns warning status"""
         self.scp = DummyGetSCP()
-        def on_c_store(ds):
+        def on_c_store(ds, sop_class):
             return 0xB000
         # SCP should override final success status
         self.scp.statuses = [0xFF00]
@@ -1845,7 +1845,7 @@ class TestQRMoveServiceClass(unittest.TestCase):
     def test_move_callback_exception(self):
         """Test SCP handles on_c_move yielding an exception"""
         self.scp = DummyMoveSCP()
-        def on_c_move(ds, dest): raise ValueError
+        def on_c_move(ds, dest, sop_class): raise ValueError
         self.scp.ae.on_c_move = on_c_move
         self.scp.start()
 


### PR DESCRIPTION
C-FIND callback needs to know which SOPClass called it, so it can determine through what to search, e.g. images or worklists.