### PR TITLE
Make Association thread-safe

### DIFF
--- a/pynetdicom3/association.py
+++ b/pynetdicom3/association.py
@@ -89,6 +89,7 @@ class Association(threading.Thread):
     scp_supported_sop : list of pynetdicom3.sop_class.ServiceClass
         A list of the supported SOP classes when acting as an SCP.
     """
+
     def __init__(self, local_ae, client_socket=None, peer_ae=None,
                  acse_timeout=60, dimse_timeout=None, max_pdu=16382,
                  ext_neg=None):


### PR DESCRIPTION
cf #137 

This is obviously not ready, but i opened a PR for the purpose of discussion.

Associations are not thread safe, this intend to create and use them from different threads at the same time.

How to test it: 
run https://gist.github.com/rdebroiz/4dcc59217bc5b5a88f17116c6df05261
SCP: `python3 pynetdicom_thread.py scp 100`
SCU: `python3 pynetdicom_thread.py scu any/dicom/file.dcm 100 100`

It will launch 100 consumer threads, each thread creates its own association and use it to send 100 C-STORE messages. I attached a DICOM  file from the GDCM test database which can be used.

[CT-MONO2-16-chest.txt](https://github.com/pydicom/pynetdicom3/files/1910509/CT-MONO2-16-chest.txt)

Surround `self.dimse.send_msg(req, context_id)` in `send_c_store` with a lock seems to fix all errors that i had without it on the SCU side, demonstrating that the problem is indeed thread-safe related.