### PR TITLE
[MRG] Improve unit test coverage for the finite state machine

### DIFF
--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -54,3 +54,4 @@ Changes
   ``ACSE.negotiate_release`` instead.
 * The association acceptor no longer aborts an accepted association if there
   are no accepted presentation contexts. The association requestor still does.
+* Default ACSE timeout changed to 30 s and default network timeout to 60 s.

--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -47,14 +47,10 @@ Changes
   association requests will be rejected unless the value of the *Called AE
   Title* parameter matches ``AE.ae_title``. If False (default) then no matching
   will be performed and all associations accepted (unless rejected for other
-<<<<<<< HEAD
   reasons). (:issue:`184`)
-* The association acceptor no longer aborts an accepted association if there
-  are no accepted presentation contexts. The association requestor still does.
-=======
-  reasons).
 * ``ACSE.is_released`` is deprecated and will be removed in v1.2. Use
   ``ACSE.is_release_requested`` instead.
 * ``ACSE.release_association`` is deprecated and will be removed in v1.2. Use
   ``ACSE.negotiate_release`` instead.
->>>>>>> d6c34fb82f46edc9950323a3fd11b58cd129f148
+* The association acceptor no longer aborts an accepted association if there
+  are no accepted presentation contexts. The association requestor still does.

--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -11,7 +11,7 @@ Fixes
 * ``DIMSEMessage`` subclass creation and ``DIMSEMessage.primitive_to_message``
   should now be thread-safe (:issue:`137`)
 * Fixed A-RELEASE collision not being implemented correctly. (:issue:`269`)
-* Fixed bug in ``fsm.AR_8``
+* Fixed bugs in ``fsm.AR_8`` and ``fsm.AA_7``.
 * Fixed DUL not handling the service user sending A-P-ABORT primitives.
   (:issue:`270`)
 * Fixed the DUL endlessly waiting in State 13 if the remote didn't

--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -41,3 +41,5 @@ Changes
   Title* parameter matches ``AE.ae_title``. If False (default) then no matching
   will be performed and all associations accepted (unless rejected for other
   reasons). (:issue:`184`)
+* The association acceptor no longer aborts an accepted association if there
+  are no accepted presentation contexts. The association requestor still does.

--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -10,12 +10,14 @@ Fixes
 * Completely fixed handling a maximum PDU length of 0. (:issue:`193`)
 * ``DIMSEMessage`` subclass creation and ``DIMSEMessage.primitive_to_message``
   should now be thread-safe (:issue:`137`)
+* Fixed ``ACSE.send_ap_abort`` not working correctly (:pull_request:`268`).
 
 Enhancements
 ............
 
 * Added ``select_timeout`` parameter to ``Association.start()`` to allow the
   user to specify how long the select.select() call blocks for.
+  (:pull_request:`260`)
 * Improved the CPU usage of the AE when running idle as an SCP (:issue:`60`).
 
 
@@ -33,8 +35,9 @@ Changes
   will be rejected unless the value of the *Calling AE Title* parameter matches
   one of those in the list. If set to an empty list (default) then all
   associations will be accepted (unless rejected for other reasons).
+  (:issue:`192`)
 * ``AE.require_called_aet`` should now be set using a bool. If True then any
   association requests will be rejected unless the value of the *Called AE
   Title* parameter matches ``AE.ae_title``. If False (default) then no matching
   will be performed and all associations accepted (unless rejected for other
-  reasons).
+  reasons). (:issue:`184`)

--- a/docs/changelog/v1.1.0.rst
+++ b/docs/changelog/v1.1.0.rst
@@ -11,6 +11,9 @@ Fixes
 * ``DIMSEMessage`` subclass creation and ``DIMSEMessage.primitive_to_message``
   should now be thread-safe (:issue:`137`)
 * Fixed ``ACSE.send_ap_abort`` not working correctly (:pull_request:`268`).
+* Fixed handling of P-DATA-TF PDUs received after sending an A-RELEASE-RQ PDU
+  (:pull_request:`268`).
+* Fixed release collision not working correctly (:pull_request:`268`).
 
 Enhancements
 ............

--- a/docs/user/ae.rst
+++ b/docs/user/ae.rst
@@ -402,8 +402,8 @@ verifying its identity. Possible forms of identity confirmation methods are:
 * SAML assertion
 * JSON web token
 
-By default all association requests that include a user identity negotiation
-requests are accepted (provided there's no other reason to reject) and
+By default all association requests that include user identity negotiation
+are accepted (provided there's no other reason to reject) and
 no user identity negotiation response is sent even if one is requested.
 
 To handle the user identity negotiation yourself you should implement the

--- a/docs/user/presentation.rst
+++ b/docs/user/presentation.rst
@@ -337,7 +337,7 @@ following table to decide the outcome of role selection negotiation:
 +---------------------+---------------------+----------------------+----------+
 | Requestor           | Acceptor            | Outcome              | Notes    |
 +----------+----------+----------+----------+-----------+----------+          |
-| scu_role | scp_role | scu_role | scp_role | Requestor | Acceptor`|          |
+| scu_role | scp_role | scu_role | scp_role | Requestor | Acceptor |          |
 +==========+==========+==========+==========+===========+==========+==========+
 | N/A      | N/A      | N/A      | N/A      | SCU       | SCP      | Default  |
 +----------+----------+----------+----------+-----------+----------+----------+

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -2,9 +2,10 @@
 ACSE service provider
 """
 import logging
+import time
 
 from pynetdicom.pdu_primitives import (
-    A_ASSOCIATE, A_RELEASE, A_ABORT, A_P_ABORT,
+    A_ASSOCIATE, A_RELEASE, A_ABORT, A_P_ABORT, P_DATA,
     AsynchronousOperationsWindowNegotiation,
     SOPClassCommonExtendedNegotiation,
     SOPClassExtendedNegotiation,
@@ -13,6 +14,7 @@ from pynetdicom.pdu_primitives import (
 from pynetdicom.presentation import (
     negotiate_as_requestor, negotiate_as_acceptor
 )
+from pynetdicom.timer import Timer
 from pynetdicom.utils import pretty_bytes
 from pynetdicom._globals import APPLICATION_CONTEXT_NAME
 
@@ -491,10 +493,8 @@ class ACSE(object):
 
     def release_association(self, assoc):
         """Release an established association.
-
         Sends an A-RELEASE request and waits for the response. If no response
         is received then aborts the association instead.
-
         Parameters
         ----------
         assoc : association.Association

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -378,12 +378,6 @@ class ACSE(object):
         assoc.debug_association_accepted(assoc.acceptor.primitive)
         assoc.ae.on_association_accepted(assoc.acceptor.primitive)
 
-        # No valid presentation contexts, abort the association
-        if not assoc.accepted_contexts:
-            self.send_abort(assoc, 0x02)
-            assoc.kill()
-            return
-
         # Assocation established OK
         assoc.is_established = True
 

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -2,11 +2,10 @@
 ACSE service provider
 """
 import logging
-import time
 import warnings
 
 from pynetdicom.pdu_primitives import (
-    A_ASSOCIATE, A_RELEASE, A_ABORT, A_P_ABORT, P_DATA,
+    A_ASSOCIATE, A_RELEASE, A_ABORT, A_P_ABORT,
     AsynchronousOperationsWindowNegotiation,
     SOPClassCommonExtendedNegotiation,
     SOPClassExtendedNegotiation,
@@ -15,7 +14,6 @@ from pynetdicom.pdu_primitives import (
 from pynetdicom.presentation import (
     negotiate_as_requestor, negotiate_as_acceptor
 )
-from pynetdicom.timer import Timer
 from pynetdicom.utils import pretty_bytes
 from pynetdicom._globals import APPLICATION_CONTEXT_NAME
 
@@ -871,7 +869,8 @@ class ACSE(object):
     def debug_send_associate_ac(a_associate_ac):
         """
         Placeholder for a function callback. Function will be called
-        immediately prior to encoding and sending an A-ASSOCIATE-AC to a peer AE
+        immediately prior to encoding and sending an A-ASSOCIATE-AC to a peer
+        AE
 
         Parameters
         ----------
@@ -982,8 +981,9 @@ class ACSE(object):
 
 
         s.append('User Identity Negotiation Response: {0!s}'.format(usr_id))
-        s.append('======================= END A-ASSOCIATE-AC =================='
-                 '====')
+        s.append(
+            '======================= END A-ASSOCIATE-AC ======================'
+        )
 
         for line in s:
             LOGGER.debug(line)
@@ -992,7 +992,8 @@ class ACSE(object):
     def debug_send_associate_rj(a_associate_rj):
         """
         Placeholder for a function callback. Function will be called
-        immediately prior to encoding and sending an A-ASSOCIATE-RJ to a peer AE
+        immediately prior to encoding and sending an A-ASSOCIATE-RJ to a peer
+        AE.
 
         Parameters
         ----------
@@ -1171,8 +1172,9 @@ class ACSE(object):
         else:
             s.append('Requested User Identity Negotiation: None')
 
-        s.append('======================= END A-ASSOCIATE-RQ =================='
-                 '====')
+        s.append(
+            '======================= END A-ASSOCIATE-RQ ======================'
+        )
 
         for line in s:
             LOGGER.debug(line)
@@ -1228,12 +1230,14 @@ class ACSE(object):
             The A-ABORT PDU instance
         """
         s = ['Abort Parameters:']
-        s.append('========================== BEGIN A-ABORT ===================='
-                 '====')
+        s.append(
+            '========================== BEGIN A-ABORT ========================'
+        )
         s.append('Abort Source: {0!s}'.format(a_abort.source_str))
         s.append('Abort Reason: {0!s}'.format(a_abort.reason_str))
-        s.append('=========================== END A-ABORT ====================='
-                 '====')
+        s.append(
+            '=========================== END A-ABORT ========================='
+        )
         for line in s:
             LOGGER.debug(line)
 
@@ -1345,8 +1349,9 @@ class ACSE(object):
         usr_id = 'Yes' if user_info.user_identity is not None else 'None'
 
         s.append('User Identity Negotiation Response: {0!s}'.format(usr_id))
-        s.append('======================= END A-ASSOCIATE-AC =================='
-                 '====')
+        s.append(
+            '======================= END A-ASSOCIATE-AC ======================'
+        )
 
         for line in s:
             LOGGER.debug(line)
@@ -1368,13 +1373,15 @@ class ACSE(object):
         assoc_rj = a_associate_rj
 
         s = ['Reject Parameters:']
-        s.append('====================== BEGIN A-ASSOCIATE-RJ ================='
-                 '=====')
+        s.append(
+            '====================== BEGIN A-ASSOCIATE-RJ ====================='
+        )
         s.append('Result:    {0!s}'.format(assoc_rj.result_str))
         s.append('Source:    {0!s}'.format(assoc_rj.source_str))
         s.append('Reason:    {0!s}'.format(assoc_rj.reason_str))
-        s.append('======================= END A-ASSOCIATE-RJ =================='
-                 '====')
+        s.append(
+            '======================= END A-ASSOCIATE-RJ ======================'
+        )
         for line in s:
             LOGGER.debug(line)
 
@@ -1552,8 +1559,9 @@ class ACSE(object):
         else:
             s.append('Requested User Identity Negotiation: None')
 
-        s.append('======================= END A-ASSOCIATE-RQ =================='
-                 '====')
+        s.append(
+            '======================= END A-ASSOCIATE-RQ ======================'
+        )
 
         for line in s:
             LOGGER.debug(line)

--- a/pynetdicom/ae.py
+++ b/pynetdicom/ae.py
@@ -64,7 +64,7 @@ class ApplicationEntity(object):
         messages. A value of ``None`` means no timeout. (default: None)
     network_timeout : int or float or None
         The maximum amount of time (in seconds) to wait for network messages.
-        A value of ``None`` means no timeout. (default: None)
+        A value of ``None`` means no timeout. (default: 60)
     maximum_associations : int
         The maximum number of simultaneous associations (default: 2)
     maximum_pdu_size : int
@@ -202,7 +202,7 @@ class ApplicationEntity(object):
 
         # Default timeouts - None means no timeout
         self.acse_timeout = 30
-        self.network_timeout = None
+        self.network_timeout = 60
         self.dimse_timeout = None
 
         # Require Calling/Called AE titles to match if value is non-empty str
@@ -809,8 +809,8 @@ class ApplicationEntity(object):
         elif isinstance(value, (int, float)) and value >= 0:
             self._network_timeout = value
         else:
-            LOGGER.warning("network_timeout set to never expire")
-            self._network_timeout = None
+            LOGGER.warning("network_timeout set to 60 s")
+            self._network_timeout = 60
 
         for assoc in self.active_associations:
             assoc.dul.dul_timeout = self.network_timeout

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -250,7 +250,7 @@ class DULServiceProvider(Thread):
                 if self._is_artim_expired():
                     self._kill_thread = True
 
-            except:
+            except Exception as exc:
                 # FIXME: This catch all should be removed
                 self._kill_thread = True
                 raise

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -177,11 +177,6 @@ class DULServiceProvider(Thread):
         """Immediately interrupts the thread"""
         self._kill_thread = True
 
-    def on_receive_pdu(self):
-        """Called after the first byte of an incoming PDU is read.
-        """
-        pass
-
     def peek_next_pdu(self):
         """Check the next PDU to be processed."""
         try:
@@ -202,14 +197,14 @@ class DULServiceProvider(Thread):
             `timeout` seconds. Otherwise returns an item if one is immediately
             available.
         timeout : int or None
-            See the definition of `Wait`
+            See the definition of `wait`
 
         Returns
         -------
         queue_item
-            The next object in the to_user_queue [FIXME]
+            The next object in the to_user_queue.
         None
-            If the queue is empty
+            If the queue is empty.
         """
         try:
             # Remove and return an item from the queue

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -19,7 +19,9 @@ from pynetdicom.pdu import (
     A_ASSOCIATE_RQ, A_ASSOCIATE_AC, A_ASSOCIATE_RJ,
     P_DATA_TF, A_RELEASE_RQ, A_RELEASE_RP, A_ABORT_RQ
 )
-from pynetdicom.pdu_primitives import A_ASSOCIATE, A_RELEASE, A_ABORT, P_DATA
+from pynetdicom.pdu_primitives import (
+    A_ASSOCIATE, A_RELEASE, A_ABORT, P_DATA, A_P_ABORT
+)
 from pynetdicom.timer import Timer
 
 LOGGER = logging.getLogger('pynetdicom.dul')
@@ -538,7 +540,7 @@ class DULServiceProvider(Thread):
                 # A-Release Response
                 # result is 'affirmative'
                 event_str = 'Evt14'
-        elif primitive.__class__ == A_ABORT:
+        elif primitive.__class__ in (A_ABORT, A_P_ABORT):
             event_str = 'Evt15'
         elif primitive.__class__ == P_DATA:
             event_str = 'Evt9'

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -411,7 +411,7 @@ class DULServiceProvider(Thread):
                 return False
 
             # Check to see if there's more data to be read
-            #   Might be any incoming PDU or invalid data
+            #   Might be any incoming PDU or valid/invalid data
             # Make sure our check of the socket is non-blocking!
             try:
                 ready, _, _ = select.select([self.scu_socket], [], [], 0)

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -14,7 +14,7 @@ from struct import unpack
 from threading import Thread
 import time
 
-from pynetdicom.fsm import StateMachine
+from pynetdicom.fsm import StateMachine, InvalidEventError
 from pynetdicom.pdu import (
     A_ASSOCIATE_RQ, A_ASSOCIATE_AC, A_ASSOCIATE_RJ,
     P_DATA_TF, A_RELEASE_RQ, A_RELEASE_RP, A_ABORT_RQ

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -411,7 +411,7 @@ class DULServiceProvider(Thread):
                 return False
 
             # Check to see if there's more data to be read
-            #   Might be any incoming PDU
+            #   Might be any incoming PDU or invalid data
             # Make sure our check of the socket is non-blocking!
             try:
                 ready, _, _ = select.select([self.scu_socket], [], [], 0)

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -927,6 +927,7 @@ def AA_4(dul):
     # Issue A-P-ABORT indication primitive.
     dul.primitive = A_ABORT()
     dul.to_user_queue.put(dul.primitive)
+    dul.kill_dul()
 
     return 'Sta1'
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -311,8 +311,8 @@ def AE_6(dul):
     # If A-ASSOCIATE-RQ not acceptable by service dul provider
     #   Then set reason and send -RJ PDU back to peer
     if dul.pdu.protocol_version != 0x0001:
-        LOGGER.error("Receiving Association failed: Unsupported peer protocol "
-                     "version '0x%04x' (0x0001 expected)",
+        LOGGER.error("A-ASSOCIATE-RQ: Unsupported protocol "
+                     "version '0x%04x'",
                      dul.pdu.protocol_version)
 
         # Send A-ASSOCIATE-RJ PDU and start ARTIM timer
@@ -713,7 +713,7 @@ def AR_8(dul):
     """
     # Issue A-RELEASE indication (release collision)
     dul.to_user_queue.put(dul.primitive)
-    if dul.requestor == 1:
+    if dul.assoc.is_requestor:
         return 'Sta9'
 
     return 'Sta10'

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -70,7 +70,7 @@ class StateMachine(object):
             # Execute the required action
             next_state = action[1](self.dul)
 
-            print(action_name, self.current_state, event, next_state)
+            #print(action_name, self.current_state, event, next_state)
 
             # Move the state machine to the next state
             self.transition(next_state)

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -14,6 +14,11 @@ from pynetdicom.pdu_primitives import A_ABORT
 LOGGER = logging.getLogger('pynetdicom.sm')
 
 
+class InvalidEventError(Exception):
+    """Exception for use when an invalid event occurs for a given state."""
+    pass
+
+
 # pylint: disable=invalid-name
 class StateMachine(object):
     """Implementation of the DICOM Upper Layer State Machine.
@@ -52,11 +57,11 @@ class StateMachine(object):
         # Check (event + state) is valid
         if (event, self.current_state) not in TRANSITION_TABLE:
             msg = (
-                "DUL State Machine received an invalid event '{}' for the "
-                "current state '{}'".format(event, self.current_state)
+                "Invalid event '{}' for the current state '{}'"
+                .format(event, self.current_state)
             )
             LOGGER.error(msg)
-            raise KeyError(msg)
+            raise InvalidEventError(msg)
 
         action_name = TRANSITION_TABLE[(event, self.current_state)]
 
@@ -70,7 +75,10 @@ class StateMachine(object):
             # Execute the required action
             next_state = action[1](self.dul)
 
-            #print(action_name, self.current_state, event, next_state)
+            print(
+                "{} + {} -> {} -> {}"
+                .format(self.current_state, event, action_name, next_state)
+            )
 
             # Move the state machine to the next state
             self.transition(next_state)

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -4,15 +4,17 @@ The DUL's finite state machine representation.
 import logging
 import socket
 
-from pynetdicom.pdu import (A_ASSOCIATE_RQ, A_ASSOCIATE_RJ, A_ASSOCIATE_AC,
-                            P_DATA_TF, A_RELEASE_RQ, A_RELEASE_RP, A_ABORT_RQ)
+from pynetdicom.pdu import (
+    A_ASSOCIATE_RQ, A_ASSOCIATE_RJ, A_ASSOCIATE_AC,
+    P_DATA_TF, A_RELEASE_RQ, A_RELEASE_RP, A_ABORT_RQ
+)
 from pynetdicom.pdu_primitives import A_ABORT
+
 
 LOGGER = logging.getLogger('pynetdicom.sm')
 
+
 # pylint: disable=invalid-name
-
-
 class StateMachine(object):
     """Implementation of the DICOM Upper Layer State Machine.
 
@@ -20,7 +22,7 @@ class StateMachine(object):
     ----------
     current_state : str
         The current state of the state machine, 'Sta1' to 'Sta13'.
-    dul : pynetdicom.dul.DULServiceProvider
+    dul : dul.DULServiceProvider
         The DICOM Upper Layer service instance for the local AE
 
     References
@@ -33,8 +35,8 @@ class StateMachine(object):
 
         Parameters
         ---------
-        dul : pynetdicom.dul.DULServiceProvider
-            The DICOM Upper Layer Service instance for the local AE.
+        dul : dul.DULServiceProvider
+            The DICOM Upper Layer Service instance for the association.
         """
         self.current_state = 'Sta1'
         self.dul = dul
@@ -49,12 +51,12 @@ class StateMachine(object):
         """
         # Check (event + state) is valid
         if (event, self.current_state) not in TRANSITION_TABLE:
-            LOGGER.error("DUL State Machine received an invalid event '%s' "
-                         "for the current state '%s'",
-                         event, self.current_state)
-            raise KeyError("DUL State Machine received an invalid event "
-                           "'{}' for the current state '{}'"
-                           .format(event, self.current_state))
+            msg = (
+                "DUL State Machine received an invalid event '{}' for the "
+                "current state '{}'".format(event, self.current_state)
+            )
+            LOGGER.error(msg)
+            raise KeyError(msg)
 
         action_name = TRANSITION_TABLE[(event, self.current_state)]
 
@@ -68,15 +70,16 @@ class StateMachine(object):
             # Execute the required action
             next_state = action[1](self.dul)
 
-            #print(action_name, self.current_state, event, next_state)
+            print(action_name, self.current_state, event, next_state)
 
             # Move the state machine to the next state
             self.transition(next_state)
 
-        except Exception:
+        except Exception as exc:
             LOGGER.error("DUL State Machine received an exception attempting "
                          "to perform the action '%s' while in state '%s'",
                          action_name, self.current_state)
+            LOGGER.exception(exc)
             self.dul.kill_dul()
             raise
 
@@ -97,7 +100,7 @@ class StateMachine(object):
         if state in STATES.keys():
             self.current_state = state
         else:
-            msg = 'Invalid state "{}" for State Machine'.format(state)
+            msg = "Invalid state '{}' for State Machine".format(state)
             LOGGER.error(msg)
             raise ValueError(msg)
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -568,8 +568,10 @@ def AR_3(dul):
     """
     # Issue A-RELEASE confirmation primitive and close transport connection
     dul.to_user_queue.put(dul.primitive)
+    dul.scu_socket.shutdown(socket.SHUT_RDWR)
     dul.scu_socket.close()
     dul.peer_socket = None
+    dul.kill_dul()
 
     return 'Sta1'
 
@@ -633,6 +635,7 @@ def AR_5(dul):
     """
     # Stop ARTIM timer
     dul.artim_timer.stop()
+    dul.kill_dul()
 
     return 'Sta1'
 
@@ -818,16 +821,8 @@ def AA_1(dul):
     # if already started) ARTIM timer.
     dul.pdu = A_ABORT_RQ()
     dul.pdu.source = 0x00
-
-    # The reason for the abort should really be roughly defined by the
-    #   current state of the State Machine
-    if dul.state_machine.current_state == 'Sta2':
-        # Unexpected PDU
-        dul.pdu.reason_diagnostic = 0x02
-    else:
-        # Reason not specified
-        dul.pdu.reason_diagnostic = 0x00
-
+    # Reason not specified
+    dul.pdu.reason_diagnostic = 0x00
     dul.pdu.from_primitive(dul.primitive)
 
     # Callback

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -75,10 +75,11 @@ class StateMachine(object):
             # Execute the required action
             next_state = action[1](self.dul)
 
-            print(
-                "{} + {} -> {} -> {}"
-                .format(self.current_state, event, action_name, next_state)
-            )
+            # Useful for debugging
+            #print(
+            #    "{} + {} -> {} -> {}"
+            #    .format(self.current_state, event, action_name, next_state)
+            #)
 
             # Move the state machine to the next state
             self.transition(next_state)
@@ -153,6 +154,8 @@ def AE_1(dul):
         LOGGER.error("TCP Initialisation Error: Connection refused")
         dul.to_user_queue.put(None)
         dul.scu_socket.close()
+        dul.kill_dul()
+
         return 'Sta1'
 
     return 'Sta4'
@@ -249,6 +252,7 @@ def AE_4(dul):
     dul.to_user_queue.put(dul.primitive)
     dul.scu_socket.close()
     dul.peer_socket = None
+    dul.kill_dul()
 
     return 'Sta1'
 
@@ -862,6 +866,7 @@ def AA_2(dul):
     dul.scu_socket.shutdown(socket.SHUT_RDWR)
     dul.scu_socket.close()
     dul.peer_socket = None
+    dul.kill_dul()
 
     return 'Sta1'
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -955,6 +955,7 @@ def AA_5(dul):
     """
     # Stop ARTIM timer.
     dul.artim_timer.stop()
+    dul.kill_dul()
 
     return 'Sta1'
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -1011,13 +1011,14 @@ def AA_7(dul):
         Sta13, the next state of the state machine
     """
     # Send A-ABORT PDU.
-    dul.pdu = A_ABORT_RQ()
-    dul.pdu.from_primitive(dul.primitive)
+    pdu = A_ABORT_RQ()
+    pdu.source = 0x02
+    pdu.reason_diagnostic = 0x02
 
     # Callback
-    dul.assoc.acse.debug_send_abort(dul.pdu)
+    dul.assoc.acse.debug_send_abort(pdu)
 
-    dul.scu_socket.send(dul.pdu.encode())
+    dul.scu_socket.send(pdu.encode())
 
     return 'Sta13'
 

--- a/pynetdicom/tests/dummy_c_scp.py
+++ b/pynetdicom/tests/dummy_c_scp.py
@@ -88,6 +88,7 @@ class DummyBaseSCP(threading.Thread):
         self.ae.on_n_action = self.on_n_action
         self.ae.on_n_create = self.on_n_create
         self.ae.on_n_delete = self.on_n_delete
+        self.ae.network_timeout = 5
 
         threading.Thread.__init__(self)
         self.daemon = True

--- a/pynetdicom/tests/test_ae.py
+++ b/pynetdicom/tests/test_ae.py
@@ -624,13 +624,13 @@ class TestAEGoodTimeoutSetters(object):
     def test_network_timeout(self):
         """ Check AE network timeout change produces good value """
         ae = AE()
-        assert ae.network_timeout is None
+        assert ae.network_timeout == 60
         ae.network_timeout = None
         assert ae.network_timeout is None
         ae.network_timeout = -100
-        assert ae.network_timeout is None
+        assert ae.network_timeout == 60
         ae.network_timeout = 'a'
-        assert ae.network_timeout is None
+        assert ae.network_timeout == 60
         ae.network_timeout = 0
         assert ae.network_timeout == 0
         ae.network_timeout = 30

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -431,8 +431,8 @@ class TestAssociation(object):
     def test_scp_assoc_a_abort_reply(self):
         """Test SCP sending an A-ABORT instead of an A-ASSOCIATE response"""
         self.scp = DummyVerificationSCP()
-        self.scp.ae._handle_connection = self.scp.dev_handle_connection
         self.scp.send_a_abort = True
+        self.scp.ae._handle_connection = self.scp.dev_handle_connection
         self.scp.start()
 
         ae = AE()
@@ -441,14 +441,15 @@ class TestAssociation(object):
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert not assoc.is_established
+        assert assoc.is_aborted
 
         self.scp.stop()
 
     def test_scp_assoc_ap_abort_reply(self):
         """Test SCP sending an A-P-ABORT instead of an A-ASSOCIATE response"""
         self.scp = DummyVerificationSCP()
-        self.scp.ae._handle_connection = self.scp.dev_handle_connection
         self.scp.send_ap_abort = True
+        self.scp.ae._handle_connection = self.scp.dev_handle_connection
         self.scp.start()
 
         ae = AE()
@@ -457,6 +458,7 @@ class TestAssociation(object):
         ae.dimse_timeout = 5
         assoc = ae.associate('localhost', 11112)
         assert not assoc.is_established
+        assert assoc.is_aborted
 
         self.scp.stop()
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -1,0 +1,192 @@
+"""Unit tests for fsm.py"""
+
+import queue
+import socket
+import threading
+import time
+
+import pytest
+
+from pynetdicom import AE
+from pynetdicom.association import Association
+from pynetdicom.fsm import *
+from pynetdicom.sop_class import VerificationSOPClass
+from .dummy_c_scp import DummyVerificationSCP, DummyBaseSCP
+
+
+REFERENCE_BAD_EVENTS = [
+    # Event, bad states
+    ("Evt1", [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE (rq) p
+    ("Evt2", [1, 2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # Connection available
+    ("Evt3", [1, 4]),  # A-ASSOCIATE-AC PDU recv
+    ("Evt4", [1, 4]),  # A-ASSOCIATE-RJ PDU recv
+    ("Evt5", [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # Connection open
+    ("Evt6", [1, 4]),  # A-ASSOCIATE-RQ PDU recv
+    ("Evt7", [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE (ac) p
+    ("Evt8", [1, 2, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE (rj) p
+    ("Evt9", [1, 2, 3, 4, 5, 7, 9, 10, 11, 12, 13]),  # P-DATA primitive
+    ("Evt10", [1, 4]),  # P-DATA-TF PDU
+    ("Evt11", [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13]),  # A-RELEASE (rq) p
+    ("Evt12", [1, 4]),  # A-RELEASE-RQ PDU recv
+    ("Evt13", [1, 4]),  # A-RELEASE-RP PDU recv
+    ("Evt14", [1, 2, 3, 4, 5, 6, 7, 10, 11, 13]),  # A-RELEASE (rsp) primitive
+    ("Evt15", [1, 2, 13]),  # A-ABORT (rq) primitive
+    ("Evt16", [1, 4]),  # A-ABORT PDU recv
+    ("Evt17", [1]),  # Connection closed
+    ("Evt18", [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),  # ARTIM expired
+    ("Evt19", [1, 4]),  # Unrecognised PDU rev
+]
+REFERENCE_GOOD_EVENTS = [
+    # Event, good states
+    ("Evt1", [1]),  # A-ASSOCIATE (rq) p
+    ("Evt2", [4]),  # Connection available
+    ("Evt3", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE-AC PDU recv
+    ("Evt4", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE-RJ PDU recv
+    ("Evt5", [1]),  # Connection open
+    ("Evt6", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ASSOCIATE-RQ PDU recv
+    ("Evt7", [3]),  # A-ASSOCIATE (ac) p
+    ("Evt8", [3]),  # A-ASSOCIATE (rj) p
+    ("Evt9", [6, 8]),  # P-DATA primitive
+    ("Evt10", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # P-DATA-TF PDU
+    ("Evt11", [6]),  # A-RELEASE (rq) p
+    ("Evt12", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-RELEASE-RQ PDU recv
+    ("Evt13", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-RELEASE-RP PDU recv
+    ("Evt14", [8, 9, 12]),  # A-RELEASE (rsp) primitive
+    ("Evt15", [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),  # A-ABORT (rq) primitive
+    ("Evt16", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # A-ABORT PDU recv
+    ("Evt17", [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # Connection closed
+    ("Evt18", [2, 13]),  # ARTIM expired
+    ("Evt19", [2, 3, 5, 6, 7, 8, 9, 10, 11, 12, 13]),  # Unrecognised PDU rev
+]
+
+
+class BadDUL(object):
+    """A DUL that always raises an exception during actions."""
+    def __init__(self):
+        self.is_killed = False
+
+    def kill_dul(self):
+        self.is_killed = True
+
+
+class TestStateMachine(object):
+    """Non-functional unit tests for fsm.StateMachine."""
+    def setup(self):
+        """Run prior to each test"""
+        self.scp = None
+
+    def teardown(self):
+        """Clear any active threads"""
+        if self.scp:
+            self.scp.abort()
+
+        time.sleep(0.1)
+
+        for thread in threading.enumerate():
+            if isinstance(thread, DummyBaseSCP):
+                thread.abort()
+                thread.stop()
+
+    def test_init(self):
+        """Test creation of new StateMachine."""
+        #self.scp = DummyVerificationSCP()
+        #self.scp.start()
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+
+        assoc = Association(ae, mode='requestor')
+
+        fsm = assoc.dul.state_machine
+        assert fsm.current_state == 'Sta1'
+        assert fsm.dul == assoc.dul
+
+        #self.scp.stop()
+
+    def test_invalid_transition_raises(self):
+        """Test StateMachine.transition using invalid states raises."""
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+
+        assoc = Association(ae, mode='requestor')
+
+        fsm = assoc.dul.state_machine
+        msg = r"Invalid state 'Sta0' for State Machine"
+        with pytest.raises(ValueError, match=msg):
+            fsm.transition('Sta0')
+
+    def test_valid_transition(self):
+        """Test StateMachine.transition using valid states."""
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+
+        assoc = Association(ae, mode='requestor')
+        fsm = assoc.dul.state_machine
+
+        for ii in range(1, 14):
+            assert 1 <= ii <= 13
+            fsm.transition("Sta{}".format(ii))
+            assert fsm.current_state == "Sta{}".format(ii)
+
+    @pytest.mark.parametrize("event, states", REFERENCE_BAD_EVENTS)
+    def test_invalid_action_raises(self, event, states):
+        """Test StateMachine.do_action raises exception if action invalid."""
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+
+        assoc = Association(ae, mode='requestor')
+        fsm = assoc.dul.state_machine
+
+        for state in states:
+            state = "Sta{}".format(state)
+            fsm.current_state = state
+
+            msg = msg = (
+                r"DUL State Machine received an invalid event '{}' for the "
+                r"current state '{}'".format(event, state)
+            )
+            with pytest.raises(KeyError, match=msg):
+                fsm.do_action(event)
+
+    @pytest.mark.parametrize("event, states", REFERENCE_GOOD_EVENTS)
+    def test_exception_during_action(self, event, states):
+        """Test an exception raised during an action kill the DUL."""
+        ae = AE()
+        ae.add_requested_context(VerificationSOPClass)
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+
+        assoc = Association(ae, mode='requestor')
+        fsm = assoc.dul.state_machine
+        fsm.dul = BadDUL()
+
+        # These event/states trigger AA-6
+        no_exception = [
+            ("Evt3", "Sta13"), ("Evt4", "Sta13"), ("Evt10", "Sta13"),
+            ("Evt12", "Sta13"), ("Evt13", "Sta13")
+        ]
+
+        for state in states:
+            fsm.dul.is_killed = False
+            if hasattr(fsm.dul, "primitive"):
+                del fsm.dul.primitive
+            assert not hasattr(fsm.dul, "primitive")
+            state = "Sta{}".format(state)
+            fsm.current_state = state
+            # AA-6 is the only action that won't raise an exception
+            if (event, state) in no_exception:
+                fsm.do_action(event)
+                assert fsm.current_state == "Sta13"
+                assert fsm.dul.primitive is None
+            else:
+                with pytest.raises(AttributeError):
+                    fsm.do_action(event)
+                assert fsm.dul.is_killed is True
+                assert fsm.current_state == state

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -1797,10 +1797,6 @@ class TestState04(TestStateBase):
 
         time.sleep(0.2)
 
-        print(self.fsm._changes)
-        print(self.fsm._transitions)
-        print(self.fsm._events)
-        print(scp.received)
         assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
@@ -5376,9 +5372,6 @@ class TestState10(TestStateBase):
 
         time.sleep(0.2)
 
-        print(self.fsm._changes)
-        print(self.fsm._transitions)
-        print(self.fsm._events)
         assert self.fsm._changes[:6] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
@@ -6799,9 +6792,6 @@ class TestState13(TestStateBase):
 
         time.sleep(0.2)
 
-        print(self.fsm._changes)
-        print(self.fsm._transitions)
-        print(self.fsm._events)
         assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
@@ -7431,8 +7421,6 @@ class TestStateMachineFunctionalRequestor(object):
 
         assert not self.assoc.is_aborted
 
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta1'  # Idle
         ]
@@ -7527,13 +7515,11 @@ class TestStateMachineFunctionalRequestor(object):
 
         assert self.assoc.is_aborted
 
-        #print(self.fsm._transitions)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
             'Sta1'  # Idle
         ]
-        #print(self.fsm._changes)
         assert self.fsm._changes == [
             ('Sta1', 'Evt1', 'AE-1'),  # recv A-ASSOC rq primitive
             ('Sta4', 'Evt2', 'AE-2'),  # connection confirmed
@@ -7560,8 +7546,6 @@ class TestStateMachineFunctionalRequestor(object):
         if self.assoc.is_established:
             self.assoc.abort()
 
-            #print(self.fsm._transitions)
-            #print(self.fsm._changes)
             assert self.fsm._transitions == [
                 'Sta4',  # Waiting for connection to complete
                 'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -7636,8 +7620,6 @@ class TestStateMachineFunctionalRequestor(object):
         while not self.assoc.is_aborted:
             time.sleep(0.05)
 
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -7671,11 +7653,6 @@ class TestStateMachineFunctionalRequestor(object):
         self.assoc.send_c_echo()
         self.assoc.release()
 
-        #while not self.assoc.is_released:
-        #    time.sleep(0.05)
-
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -7736,8 +7713,6 @@ class TestStateMachineFunctionalRequestor(object):
 
         self.assoc.release()
 
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -7797,8 +7772,6 @@ class TestStateMachineFunctionalRequestor(object):
 
         self.assoc.release()
 
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -7859,8 +7832,6 @@ class TestStateMachineFunctionalRequestor(object):
 
         self.assoc.release()
 
-        #print(self.fsm._transitions)
-        #print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU
@@ -8041,8 +8012,6 @@ class TestStateMachineFunctionalAcceptor(object):
 
         self.scp.ae.active_associations[0].release()
 
-        print(self.fsm._transitions)
-        print(self.fsm._changes)
         assert self.fsm._transitions == [
             'Sta4',  # Waiting for connection to complete
             'Sta5',  # Waiting for A-ASSOC-AC or -RJ PDU

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -3824,7 +3824,6 @@ class TestState07(TestStateBase):
 
 class TestState08(TestStateBase):
     """Tests for State 08: Awaiting A-RELEASE (rp) primitive."""
-    @pytest.mark.skip()
     def test_evt01(self):
         """Test Sta8 + Evt1."""
         # Sta8 + Evt1 -> <ignore> -> Sta8
@@ -3833,20 +3832,21 @@ class TestState08(TestStateBase):
         scp.mode = 'acceptor'
         scp.queue.put(None)
         scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
 
         scp.start()
 
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
         self.assoc.start()
 
         time.sleep(0.2)
 
-        # Need to stop the assoc reactor from responding
-        self.assoc._kill = True
-
-        scp.queue.put(['skip', a_release_rq])
-        scp.queue.put(['wait', 0.2, 'shutdown'])
-
-        time.sleep(0.2)
         self.assoc.dul.send_pdu(self.get_associate('request'))
 
         time.sleep(0.2)
@@ -3855,10 +3855,10 @@ class TestState08(TestStateBase):
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt3', 'AE-3'),
-            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta6', 'Evt12', 'AR-2'),
         ]
-        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
-        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt1']
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt1']
 
     @pytest.mark.skip()
     def test_evt02(self):
@@ -3872,14 +3872,70 @@ class TestState08(TestStateBase):
         # Sta8 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt3', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt3']
 
     def test_evt04(self):
         """Test Sta8 + Evt4."""
         # Sta8 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_associate_rj])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt4', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt4']
 
     @pytest.mark.skip()
     def test_evt05(self):
@@ -3893,81 +3949,429 @@ class TestState08(TestStateBase):
         # Sta8 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_associate_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt6', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt6']
 
     def test_evt07(self):
         """Test Sta8 + Evt7."""
         # Sta8 + Evt7 -> <ignore> -> Sta8
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_associate('accept'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt7']
 
     def test_evt08(self):
         """Test Sta8 + Evt8."""
         # Sta8 + Evt8 -> <ignore> -> Sta8
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_associate('reject'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt8']
 
     def test_evt09(self):
         """Test Sta8 + Evt9."""
         # Sta8 + Evt9 -> AR-7 -> Sta8
         # Evt9: Receive P-DATA primitive from <local user>
         # AR-7: Send P-DATA-TF PDU to <remote>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_pdata())
+
+        time.sleep(0.3)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt9']
 
     def test_evt10(self):
         """Test Sta8 + Evt10."""
         # Sta8 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', p_data_tf])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt10', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt10']
 
     def test_evt11(self):
         """Test Sta8 + Evt11."""
         # Sta8 + Evt11 -> <ignore> -> Sta8
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt11']
 
     def test_evt12(self):
         """Test Sta8 + Evt12."""
         # Sta8 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt12', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt12']
 
     def test_evt13(self):
         """Test Sta8 + Evt13."""
         # Sta8 + Evt13 -> AA-8 -> Sta13
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_release_rp])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt13', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt13']
 
     def test_evt14(self):
         """Test Sta8 + Evt14."""
         # Sta8 + Evt14 -> AR-4 -> Sta13
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
         # AR-4: Send A-RELEASE-RP PDU and start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(True))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt14']
 
     def test_evt15(self):
         """Test Sta8 + Evt15."""
         # Sta8 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
         # AA-1: Send A-ABORT PDU and start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_abort())
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt15']
 
     def test_evt16(self):
         """Test Sta8 + Evt16."""
         # Sta8 + Evt16 -> AA-3 -> Sta13
         # Evt16: Receive A-ABORT PDU from <remote>
         # AA-3: Issue A-ABORT or A-P-ABORT and close connection
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt16', 'AA-3'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt16']
 
     def test_evt17(self):
         """Test Sta8 + Evt17."""
         # Sta8 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
         # AA-4: Issue A-P-ABORT
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt17', 'AA-4'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt17']
 
     @pytest.mark.skip()
     def test_evt18(self):
@@ -3981,596 +4385,722 @@ class TestState08(TestStateBase):
         # Sta8 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
         # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', b'\x08\x00\x00\x00'])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt19', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt19']
 
 
 @pytest.mark.skip()
 class TestState09(TestStateBase):
-    """Tests for State 09: """
+    """Tests for State 09: Release collision req - awaiting A-RELEASE (rp)."""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta9 + Evt1."""
+        # Sta9 + Evt1 -> <ignore> -> Sta9
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         pass
 
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta9 + Evt2."""
+        # Sta9 + Evt2 -> <ignore> -> Sta9
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta9 + Evt3."""
+        # Sta9 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta9 + Evt4."""
+        # Sta9 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta9 + Evt5."""
+        # Sta9 + Evt5 -> <ignore> -> Sta9
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta9 + Evt6."""
+        # Sta9 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta9 + Evt7."""
+        # Sta9 + Evt7 -> <ignore> -> Sta9
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta9 + Evt8."""
+        # Sta9 + Evt8 -> <ignore> -> Sta9
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta9 + Evt9."""
+        # Sta9 + Evt9 -> <ignore> -> Sta9
         # Evt9: Receive P-DATA primitive from <local user>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta9 + Evt10."""
+        # Sta9 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta9 + Evt11."""
+        # Sta9 + Evt11 -> <ignore> -> Sta9
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta9 + Evt12."""
+        # Sta9 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta9 + Evt13."""
+        # Sta9 + Evt13 -> AA-8 -> Sta13
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta9 + Evt14."""
+        # Sta9 + Evt14 -> AR-9 -> Sta11
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        # AR-9: Send A-RELEASE-RP PDU to <remote>
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta9 + Evt15."""
+        # Sta9 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU to <remote>, start ARTIM
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta9 + Evt16."""
+        # Sta9 + Evt16 -> AA-3 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT primitive, close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta9 + Evt17."""
+        # Sta9 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT primitive
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta9 + Evt18."""
+        # Sta9 + Evt18 -> <ignore> -> Sta9
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta9 + Evt19."""
+        # Sta9 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
-        pass
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['skip', b'\x08\x00\x00\x00'])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        scp.start()
+
+        # Override ACSE.is_release_requested so the Association loop doesn't
+        #   respond to the release request
+        def is_release_requested(assoc):
+            return False
+
+        self.assoc.acse.is_release_requested = is_release_requested
+        self.assoc.start()
+
+        time.sleep(0.4)
+
+        print(self.fsm._changes)
+        print(self.fsm._transitions)
+        print(self.fsm._events)
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+            ('Sta8', 'Evt19', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt12', 'Evt19']
 
 
 @pytest.mark.skip()
 class TestState10(TestStateBase):
-    """Tests for State 10: ."""
+    """Tests for State 10: Release collision acc - awaiting A-RELEASE-RP ."""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta10 + Evt1."""
+        # Sta10 + Evt1 -> <ignore> -> Sta10
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         pass
 
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta10 + Evt2."""
+        # Sta10 + Evt2 -> <ignore> -> Sta10
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta10 + Evt3."""
+        # Sta10 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta10 + Evt4."""
+        # Sta10 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta10 + Evt5."""
+        # Sta10 + Evt5 -> <ignore> -> Sta10
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta10 + Evt6."""
+        # Sta10 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta10 + Evt7."""
+        # Sta10 + Evt7 -> <ignore> -> Sta10
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta10 + Evt8."""
+        # Sta10 + Evt8 -> <ignore> -> Sta10
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta10 + Evt9."""
+        # Sta10 + Evt9 -> <ignore> -> Sta10
         # Evt9: Receive P-DATA primitive from <local user>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta10 + Evt10."""
+        # Sta10 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta10 + Evt11."""
+        # Sta10 + Evt11 -> <ignore> -> Sta10
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta10 + Evt12."""
+        # Sta10 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta10 + Evt13."""
+        # Sta10 + Evt13 -> AR-10 -> Sta13
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AR-10: Issue A-RELEASE (rp) primitive
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta10 + Evt14."""
+        # Sta10 + Evt14 -> <ignore> -> Sta10
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta10 + Evt15."""
+        # Sta10 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU to <remote>, start ARTIM
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta10 + Evt16."""
+        # Sta10 + Evt16 -> AA-3 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT primitive, close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta10 + Evt17."""
+        # Sta10 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT primitive
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta10 + Evt18."""
+        # Sta10 + Evt18 -> <ignore> -> Sta10
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta10 + Evt19."""
+        # Sta10 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
 
 @pytest.mark.skip()
 class TestState11(TestStateBase):
-    """Tests for State 11: ."""
+    """Tests for State 11: Release collision req - awaiting A-RELEASE-RP PDU"""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta11 + Evt1."""
+        # Sta11 + Evt1 -> <ignore> -> Sta11
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         pass
 
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta11 + Evt2."""
+        # Sta11 + Evt2 -> <ignore> -> Sta11
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta11 + Evt3."""
+        # Sta11 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta11 + Evt4."""
+        # Sta11 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta11 + Evt5."""
+        # Sta11 + Evt5 -> <ignore> -> Sta11
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta11 + Evt6."""
+        # Sta11 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta11 + Evt7."""
+        # Sta11 + Evt7 -> <ignore> -> Sta11
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta11 + Evt8."""
+        # Sta11 + Evt8 -> <ignore> -> Sta11
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta11 + Evt9."""
+        # Sta11 + Evt9 -> <ignore> -> Sta11
         # Evt9: Receive P-DATA primitive from <local user>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta11 + Evt10."""
+        # Sta11 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta11 + Evt11."""
+        # Sta11 + Evt11 -> <ignore> -> Sta11
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta11 + Evt12."""
+        # Sta11 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta11 + Evt13."""
+        # Sta11 + Evt13 -> AR-3 -> Sta1
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AR-3: Issue A-RELEASE (rp) primitive and close connection
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta11 + Evt14."""
+        # Sta11 + Evt14 -> <ignore> -> Sta11
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta11 + Evt15."""
+        # Sta11 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU to <remote>, start ARTIM
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta11 + Evt16."""
+        # Sta11 + Evt16 -> AA-3 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT primitive, close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta11 + Evt17."""
+        # Sta11 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT primitive
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta11 + Evt18."""
+        # Sta11 + Evt18 -> <ignore> -> Sta11
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta11 + Evt19."""
+        # Sta11 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
 
 @pytest.mark.skip()
 class TestState12(TestStateBase):
-    """Tests for State 12: """
+    """Tests for State 12: Release collision acc - awaiting A-RELEASE (rp)"""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta12 + Evt1."""
+        # Sta12 + Evt1 -> <ignore> -> Sta12
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         pass
 
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta12 + Evt2."""
+        # Sta12 + Evt2 -> <ignore> -> Sta12
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta12 + Evt3."""
+        # Sta12 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta12 + Evt4."""
+        # Sta12 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta12 + Evt5."""
+        # Sta12 + Evt5 -> <ignore> -> Sta12
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta12 + Evt6."""
+        # Sta12 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta12 + Evt7."""
+        # Sta12 + Evt7 -> <ignore> -> Sta12
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta12 + Evt8."""
+        # Sta12 + Evt8 -> <ignore> -> Sta12
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta12 + Evt9."""
+        # Sta12 + Evt9 -> <ignore> -> Sta12
         # Evt9: Receive P-DATA primitive from <local user>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta12 + Evt10."""
+        # Sta12 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta12 + Evt11."""
+        # Sta12 + Evt11 -> <ignore> -> Sta12
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta12 + Evt12."""
+        # Sta12 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta12 + Evt13."""
+        # Sta12 + Evt13 -> AA-8 -> Sta1
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta12 + Evt14."""
+        # Sta12 + Evt14 -> AR-4 -> Sta12
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        # AR-4: Issue A-RELEASE-RP PDU and start ARTIM
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta12 + Evt15."""
+        # Sta12 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU to <remote>, start ARTIM
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta12 + Evt16."""
+        # Sta12 + Evt16 -> AA-3 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT primitive, close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta12 + Evt17."""
+        # Sta12 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT primitive
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta12 + Evt18."""
+        # Sta12 + Evt18 -> <ignore> -> Sta12
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta12 + Evt19."""
+        # Sta12 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
 
 @pytest.mark.skip()
 class TestState13(TestStateBase):
-    """Tests for State 13:"""
+    """Tests for State 13: Waiting for connection closed."""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta13 + Evt1."""
+        # Sta13 + Evt1 -> <ignore> -> Sta13
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         pass
 
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta13 + Evt2."""
+        # Sta13 + Evt2 -> <ignore> -> Sta13
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta13 + Evt3."""
+        # Sta13 + Evt3 -> AA-6 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-6: Ignore PDU
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta13 + Evt4."""
+        # Sta13 + Evt4 -> AA-6 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-6: Ignore PDU
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta13 + Evt5."""
+        # Sta13 + Evt5 -> <ignore> -> Sta13
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta13 + Evt6."""
+        # Sta13 + Evt6 -> AA-7 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-7: Send A-ABORT PDU to <remote>
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta13 + Evt7."""
+        # Sta13 + Evt7 -> <ignore> -> Sta13
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta13 + Evt8."""
+        # Sta13 + Evt8 -> <ignore> -> Sta13
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta13 + Evt9."""
+        # Sta13 + Evt9 -> <ignore> -> Sta13
         # Evt9: Receive P-DATA primitive from <local user>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta13 + Evt10."""
+        # Sta13 + Evt10 -> AA-6 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-6: Ignore PDU
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta13 + Evt11."""
+        # Sta13 + Evt11 -> <ignore> -> Sta13
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta13 + Evt12."""
+        # Sta13 + Evt12 -> AA-6 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-6: Ignore PDU
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta13 + Evt13."""
+        # Sta13 + Evt13 -> AA-6 -> Sta1
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AA-6: Ignore PDU
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta13 + Evt14."""
+        # Sta13 + Evt14 -> <ignore> -> Sta13
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta13 + Evt15."""
+        # Sta13 + Evt15 -> <ignore> -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta13 + Evt16."""
+        # Sta13 + Evt16 -> AA-2 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-2: Stop ARTIM, close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta13 + Evt17."""
+        # Sta13 + Evt17 -> AR-5 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AR-5: Stop ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta13 + Evt18."""
+        # Sta13 + Evt18 -> AA-2 -> Sta1
         # Evt18: ARTIM timer expired from <local service>
+        # AA-2: Stop ARTIM, close connection
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta13 + Evt19."""
+        # Sta13 + Evt19 -> AA-7 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-7: Send A-ABORT PDU to <remote>
         pass
 
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -3822,121 +3822,165 @@ class TestState07(TestStateBase):
         assert scp.received[2] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
 
-@pytest.mark.skip()
 class TestState08(TestStateBase):
-    """Tests for State 08: """
+    """Tests for State 08: Awaiting A-RELEASE (rp) primitive."""
+    @pytest.mark.skip()
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta8 + Evt1."""
+        # Sta8 + Evt1 -> <ignore> -> Sta8
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
 
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        # Need to stop the assoc reactor from responding
+        self.assoc._kill = True
+
+        scp.queue.put(['skip', a_release_rq])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+
+        time.sleep(0.2)
+        self.assoc.dul.send_pdu(self.get_associate('request'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt1']
+
+    @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta8 + Evt2."""
+        # Sta8 + Evt2 -> <ignore> -> Sta8
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta8 + Evt3."""
+        # Sta8 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta8 + Evt4."""
+        # Sta8 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
+    @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta8 + Evt5."""
+        # Sta8 + Evt5 -> <ignore> -> Sta8
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta8 + Evt6."""
+        # Sta8 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta8 + Evt7."""
+        # Sta8 + Evt7 -> <ignore> -> Sta8
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
         pass
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta8 + Evt8."""
+        # Sta8 + Evt8 -> <ignore> -> Sta8
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
         pass
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta8 + Evt9."""
+        # Sta8 + Evt9 -> AR-7 -> Sta8
         # Evt9: Receive P-DATA primitive from <local user>
+        # AR-7: Send P-DATA-TF PDU to <remote>
         pass
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta8 + Evt10."""
+        # Sta8 + Evt10 -> AA-8 -> Sta13
         # Evt10: Receive P-DATA-TF PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta8 + Evt11."""
+        # Sta8 + Evt11 -> <ignore> -> Sta8
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
         pass
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta8 + Evt12."""
+        # Sta8 + Evt12 -> AA-8 -> Sta13
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta8 + Evt13."""
+        # Sta8 + Evt13 -> AA-8 -> Sta13
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta8 + Evt14."""
+        # Sta8 + Evt14 -> AR-4 -> Sta13
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        # AR-4: Send A-RELEASE-RP PDU and start ARTIM
         pass
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta8 + Evt15."""
+        # Sta8 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU and start ARTIM
         pass
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta8 + Evt16."""
+        # Sta8 + Evt16 -> AA-3 -> Sta13
         # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT and close connection
         pass
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta8 + Evt17."""
+        # Sta8 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT
         pass
 
+    @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta8 + Evt18."""
+        # Sta8 + Evt18 -> <ignore> -> Sta1
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta8 + Evt19."""
+        # Sta8 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
         pass
 
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -2446,12 +2446,12 @@ class TestState05(TestStateBase):
 
         self.fsm.current_state = 'Sta13'
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt1']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt1']
 
         scp.stop()
 
@@ -2480,13 +2480,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:4] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt3', 'AE-3'),
             ('Sta6', 'Evt17', 'AA-4'),
         ]
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt3', 'Evt17']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt17']
 
     def test_evt04(self):
         """Test Sta5 + Evt4."""
@@ -2506,12 +2506,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt4', 'AE-4'),
         ]
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt4']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt4']
 
     @pytest.mark.skip()
     def test_evt05(self):
@@ -2541,12 +2541,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt6', 'AA-8'),
         ]
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt6']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt6']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
@@ -2573,12 +2573,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt7']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt7']
 
     def test_evt08(self):
         """Test Sta5 + Evt8."""
@@ -2603,12 +2603,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt8']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt8']
 
     def test_evt09(self):
         """Test Sta5 + Evt9."""
@@ -2633,12 +2633,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt9']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt9']
 
     def test_evt10(self):
         """Test Sta5 + Evt10."""
@@ -2659,13 +2659,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt10', 'AA-8'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta13']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt10']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta13']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt10']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
@@ -2692,12 +2692,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt11']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt11']
 
     def test_evt12(self):
         """Test Sta5 + Evt12."""
@@ -2718,13 +2718,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt12', 'AA-8'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta13']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt12']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta13']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt12']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
@@ -2747,13 +2747,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt13', 'AA-8'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta13']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt13']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta13']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt13']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
@@ -2780,12 +2780,12 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:2] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt14']
+        assert self.fsm._transitions[:2] == ['Sta4', 'Sta5']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt14']
 
     def test_evt15(self):
         """Test Sta5 + Evt15."""
@@ -2813,14 +2813,14 @@ class TestState05(TestStateBase):
 
         time.sleep(0.2)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:4] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt15', 'AA-1'),
             ('Sta13', 'Evt17', 'AR-5'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta13', 'Sta1']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt15', 'Evt17']
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta13', 'Sta1']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt15', 'Evt17']
 
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x00\x00'
@@ -2847,13 +2847,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt16', 'AA-3'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta1']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt16']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta1']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt16']
 
     def test_evt17(self):
         """Test Sta5 + Evt17."""
@@ -2874,13 +2874,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.5)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt17', 'AA-4'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta1']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt17']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta1']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt17']
 
     @pytest.mark.skip()
     def test_evt18(self):
@@ -2907,13 +2907,13 @@ class TestState05(TestStateBase):
 
         time.sleep(0.1)
 
-        assert self.fsm._changes == [
+        assert self.fsm._changes[:3] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
             ('Sta5', 'Evt19', 'AA-8'),
         ]
-        assert self.fsm._transitions == ['Sta4', 'Sta5', 'Sta13']
-        assert self.fsm._events == ['Evt1', 'Evt2', 'Evt19']
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta13']
+        assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt19']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -3264,8 +3264,8 @@ class TestState06(TestStateBase):
 class TestState07(TestStateBase):
     """Tests for State 07: Awaiting A-RELEASE-RP PDU."""
     def test_evt01(self):
-        """Test Sta2 + Evt1."""
-        # Sta2 + Evt1 -> <ignore> -> Sta2
+        """Test Sta7 + Evt1."""
+        # Sta7 + Evt1 -> <ignore> -> Sta7
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
         scp = DummyAE()
         scp.mode = 'acceptor'
@@ -3287,9 +3287,6 @@ class TestState07(TestStateBase):
 
         time.sleep(0.1)
 
-        print(self.fsm._changes)
-        print(self.fsm._transitions)
-        print(self.fsm._events)
         assert self.fsm._changes[:4] == [
             ('Sta1', 'Evt1', 'AE-1'),
             ('Sta4', 'Evt2', 'AE-2'),
@@ -3301,114 +3298,528 @@ class TestState07(TestStateBase):
 
     @pytest.mark.skip()
     def test_evt02(self):
-        """Test Sta2 + Evt2."""
-        # Sta2 + Evt2 -> <ignore> -> Sta2
+        """Test Sta7 + Evt2."""
+        # Sta7 + Evt2 -> <ignore> -> Sta7
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
     def test_evt03(self):
-        """Test Sta2 + Evt3."""
-        # Sta2 + Evt3 -> AA-1 -> Sta13
+        """Test Sta7 + Evt3."""
+        # Sta7 + Evt3 -> AA-8 -> Sta13
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
-        pass
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(a_associate_ac)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.3)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt3', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt3']
+
+        # Issue A-ASSOCIATE, A-RELEASE, A-ABORT PDU
+        assert scp.received[2] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
     def test_evt04(self):
-        """Test Sta2 + Evt4."""
-        # Sta2 + Evt4 -> AA-1 -> Sta13
+        """Test Sta7 + Evt4."""
+        # Sta7 + Evt4 -> AA-8 -> Sta13
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
-        pass
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(a_associate_rj)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.3)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt4', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt4']
+
+        # Issue A-ASSOCIATE, A-RELEASE, A-ABORT PDU
+        assert scp.received[2] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
     @pytest.mark.skip()
     def test_evt05(self):
-        """Test Sta2 + Evt5."""
-        # Sta2 + Evt5 -> <ignore> -> Sta2
+        """Test Sta7 + Evt5."""
+        # Sta7 + Evt5 -> <ignore> -> Sta7
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
         pass
 
     def test_evt06(self):
-        """Test Sta2 + Evt6."""
-        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        """Test Sta7 + Evt6."""
+        # Sta7 + Evt6 -> AA-8 -> Sta13
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
-        pass
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(a_associate_rq)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.3)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt6', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt6']
+
+        # Issue A-ASSOCIATE, A-RELEASE, A-ABORT PDU
+        assert scp.received[2] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
     def test_evt07(self):
-        """Test Sta2 + Evt7."""
-        # Sta2 + Evt7 -> <ignore> -> Sta2
+        """Test Sta7 + Evt7."""
+        # Sta7 + Evt7 -> <ignore> -> Sta7
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_associate('accept'))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt7']
 
     def test_evt08(self):
-        """Test Sta2 + Evt8."""
-        # Sta2 + Evt8 -> <ignore> -> Sta2
+        """Test Sta7 + Evt8."""
+        # Sta7 + Evt8 -> <ignore> -> Sta7
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_associate('reject'))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt8']
 
     def test_evt09(self):
-        """Test Sta2 + Evt9."""
-        # Sta2 + Evt9 -> <ignore> -> Sta2
+        """Test Sta7 + Evt9."""
+        # Sta7 + Evt9 -> <ignore> -> Sta7
         # Evt9: Receive P-DATA primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_pdata())
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt9']
 
     def test_evt10(self):
-        """Test Sta2 + Evt10."""
-        # Sta2 + Evt10 -> AA-1 -> Sta13
+        """Test Sta7 + Evt10."""
+        # Sta7 + Evt10 -> AR-6 -> Sta7
         # Evt10: Receive P-DATA-TF PDU from <remote>
-        pass
+        # AR-6: Send P-DATA primitive
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['skip', p_data_tf])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.2)
+
+        primitive = self.assoc.dul.receive_pdu(wait=False)
+        assert isinstance(primitive, P_DATA)
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt10', 'AR-6'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt10']
 
     def test_evt11(self):
-        """Test Sta2 + Evt11."""
-        # Sta2 + Evt11 -> <ignore> -> Sta2
+        """Test Sta7 + Evt11."""
+        # Sta7 + Evt11 -> <ignore> -> Sta7
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt11']
 
     def test_evt12(self):
-        """Test Sta2 + Evt12."""
-        # Sta2 + Evt12 -> AA-1 -> Sta13
+        """Test Sta7 + Evt12."""
+        # Sta7 + Evt12 -> AR-8 -> Sta9 or Sta10
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
-        pass
+        # AR-8: Issue A-RELEASE (rq) - release collision
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(a_release_rq)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.3)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt12', 'AR-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt12']
 
     def test_evt13(self):
-        """Test Sta2 + Evt13."""
-        # Sta2 + Evt13 -> AA-1 -> Sta13
+        """Test Sta7 + Evt13."""
+        # Sta7 + Evt13 -> AR-3 -> Sta1
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
-        pass
+        # AR-3: Issue A-RELEASE (rp) primitive and close connection
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put([a_release_rp, 'shutdown'])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.2)
+
+        primitive = self.assoc.dul.receive_pdu(wait=False)
+        assert isinstance(primitive, A_RELEASE)
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt13', 'AR-3'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt13']
 
     def test_evt14(self):
-        """Test Sta2 + Evt14."""
-        # Sta2 + Evt14 -> <ignore> -> Sta2
+        """Test Sta7 + Evt14."""
+        # Sta7 + Evt14 -> <ignore> -> Sta7
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
-        pass
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_release(True))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt14']
 
     def test_evt15(self):
-        """Test Sta2 + Evt15."""
-        # Sta2 + Evt15 -> <ignore> -> Sta2
+        """Test Sta7 + Evt15."""
+        # Sta7 + Evt15 -> AA-1 -> Sta13
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
-        pass
+        # AA-1: Send A-ABORT PDU and start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None) # release
+        scp.queue.put(None) # abort
+        scp.queue.put(['wait', 0.2,'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        self.assoc.dul.send_pdu(self.get_abort())
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt15']
 
     def test_evt16(self):
-        """Test Sta2 + Evt16."""
-        # Sta2 + Evt16 -> AA-2 -> Sta1
+        """Test Sta7 + Evt16."""
+        # Sta7 + Evt16 -> AA-3 -> Sta1
         # Evt16: Receive A-ABORT PDU from <remote>
-        pass
+        # AA-3: Issue A-ABORT or A-P-ABORT and close connection
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None) # release
+        scp.queue.put([a_abort, 'shutdown'])
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt16', 'AA-3'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt16']
 
     def test_evt17(self):
-        """Test Sta2 + Evt17."""
-        # Sta2 + Evt17 -> AA-5 -> Sta1
+        """Test Sta7 + Evt17."""
+        # Sta7 + Evt17 -> AA-4 -> Sta1
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
-        pass
+        # AA-4: Issue A-P-ABORT primitive
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt17', 'AA-4'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt17']
 
     @pytest.mark.skip()
     def test_evt18(self):
-        """Test Sta2 + Evt18."""
-        # Sta2 + Evt18 -> AA-2 -> Sta1
+        """Test Sta7 + Evt18."""
+        # Sta7 + Evt18 -> <ignore> -> Sta7
         # Evt18: ARTIM timer expired from <local service>
         pass
 
     def test_evt19(self):
-        """Test Sta2 + Evt19."""
-        # Sta2 + Evt19 -> AA-1 -> Sta13
+        """Test Sta7 + Evt19."""
+        # Sta7 + Evt19 -> AA-8 -> Sta13
         # Evt19: Received unrecognised or invalid PDU from <remote>
-        pass
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(b'\x08\x00\x00\x00')
+        scp.queue.put(['wait', 0.2, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.1)
+
+        assert self.fsm._changes[:5] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt11', 'AR-1'),
+            ('Sta7', 'Evt19', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta7']
+        assert self.fsm._events[:5] == ['Evt1', 'Evt2', 'Evt3', 'Evt11', 'Evt19']
+
+        # Issue A-ASSOCIATE, A-RELEASE, A-ABORT PDU
+        assert scp.received[2] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
 
 
 @pytest.mark.skip()

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -198,15 +198,17 @@ class DummyAE(threading.Thread):
                             self._kill = True
                             return
                         continue
-                    for item in to_send:
-                        if item == 'shutdown':
-                            self.sock.shutdown(socket.SHUT_RDWR)
-                            self.sock.close()
-                            self._kill = True
-                            return
-                        elif item == None:
-                            continue
-                        else:
+                    elif to_send[0] == 'skip':
+                        conn.send(to_send[1])
+                        continue
+                    elif to_send[1] == 'shutdown':
+                        conn.send(to_send[1])
+                        self.sock.shutdown(socket.SHUT_RDWR)
+                        self.sock.close()
+                        self._kill = True
+                        return
+                    else:
+                        for item in to_send:
                             conn.send(item)
                 else:
                     conn.send(to_send)
@@ -1122,252 +1124,118 @@ class TestState01(TestStateBase):
 @pytest.mark.skip("Need a TRANSPORT_OPEN indication")
 class TestState02(TestStateBase):
     """Tests for State 02: Connection open, waiting for A-ASSOCIATE-RQ."""
-    @pytest.mark.skip()
     def test_evt01(self):
         """Test Sta2 + Evt1."""
         # Sta2 + Evt1 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt1: A-ASSOCIATE (rq) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
-        scp = DummyAE()
-        scp.remote_port = 11112
-        scp.address = ''
+        pass
 
-        assert self.fsm.current_state == 'Sta1'
-        assert self.assoc.dul.scu_socket is None
-
-        self.assoc._mode = 'acceptor'
-        listen_socket = scp.bind_socket()
-
-        send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        send_socket.connect(('localhost', 11112))
-        #send_socket.send(p_data_tf)
-
-        ready, _, _ = select.select([listen_socket], [], [], 0.5)
-        if ready:
-            self.assoc.dul.scu_socket, _ = listen_socket.accept()
-
-        self.assoc.start()
-
-        self.fsm.current_state = 'Sta2'
-        assert self.fsm.current_state == 'Sta2'
-        self.assoc.dul.send_pdu(self.get_associate('request'))
-
-        time.sleep(0.1)
-
-        assert self.fsm._transitions == []
-        assert self.fsm._changes == []
-        #assert self.fsm._events == ['Evt5', 'Evt1']
-        assert self.fsm._events == ['Evt1']
-        assert self.fsm.current_state == 'Sta2'
-
-        self.fsm.current_state == 'Sta1'
-        self.assoc.kill()
-
-    @pytest.mark.skip()
     def test_evt02(self):
+        """Test Sta2 + Evt2."""
         # Sta2 + Evt2 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt03(self):
+        """Test Sta2 + Evt3."""
         # Sta2 + Evt3 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
-        scp = DummyAE()
-        scp.remote_port = 11112
-        scp.address = ''
-
-        assert self.fsm.current_state == 'Sta1'
-        assert self.assoc.dul.scu_socket is None
-
-        self.assoc._mode = 'acceptor'
-        listen_socket = scp.bind_socket()
-
-        send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        send_socket.connect(('localhost', 11112))
-        send_socket.send(b'')
-
-        ready, _, _ = select.select([listen_socket], [], [], 0.5)
-        if ready:
-            self.assoc.dul.scu_socket, _ = listen_socket.accept()
-
-        self.assoc.start()
-
-        time.sleep(0.1)
-
-        self.assoc.kill()
-
-        assert self.fsm._transitions == []
-        assert self.fsm._changes == []
-        print(self.fsm.current_state)
-        # Evt5 is not recorded as a unique event
-        assert self.fsm._events == ['Evt3']
+        pass
 
     def test_evt04(self):
+        """Test Sta2 + Evt4."""
         # Sta2 + Evt4 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
-        scp = DummyAE()
-        scp.remote_port = 11112
-        scp.address = ''
-
-        assert self.fsm.current_state == 'Sta1'
-        assert self.assoc.dul.scu_socket is None
-
-        self.assoc._mode = 'acceptor'
-        listen_socket = scp.bind_socket()
-
-        send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        send_socket.connect(('localhost', 11112))
-        send_socket.send(a_associate_ac)
-
-        ready, _, _ = select.select([listen_socket], [], [], 0.5)
-        if ready:
-            self.assoc.dul.scu_socket, _ = listen_socket.accept()
-
-        self.assoc.start()
-
-        time.sleep(0.1)
-
-        self.assoc.kill()
-
-        assert self.fsm._transitions == []
-        assert self.fsm._changes == []
-        # Evt5 is not recorded as a unique event
-        assert self.fsm._events == ['Evt3']
+        pass
 
     def test_evt05(self):
+        """Test Sta2 + Evt5."""
         # Sta2 + Evt5 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt5: Receive TRANSPORT_INDICATION from <transport service>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt06(self):
+        """Test Sta2 + Evt6."""
         # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
-        # AE-6: Stop ARTIM
-        #       If A-ASSOCIATE-RQ is acceptable
-        #           Send A-ASSOCIATE primitive to <local user>
-        #       Otherwise
-        #           Send A-ASSOCIATE-RJ PDU to <remote>
-        #           Start ARTIM
-        # Sta3: Awaiting A-ASSOCIATE (rsp) from <local user>
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
         pass
 
     def test_evt07(self):
+        """Test Sta2 + Evt7."""
         # Sta2 + Evt7 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt08(self):
+        """Test Sta2 + Evt8."""
         # Sta2 + Evt8 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt09(self):
+        """Test Sta2 + Evt9."""
         # Sta2 + Evt9 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt9: Receive P-DATA primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt10(self):
+        """Test Sta2 + Evt10."""
         # Sta2 + Evt10 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt10: Receive P-DATA-TF PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
         pass
 
     def test_evt11(self):
+        """Test Sta2 + Evt11."""
         # Sta2 + Evt11 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt11: Receive A-RELEASE (rq) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt12(self):
+        """Test Sta2 + Evt12."""
         # Sta2 + Evt12 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt12: Receive A-RELEASE-RQ PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
         pass
 
     def test_evt13(self):
+        """Test Sta2 + Evt13."""
         # Sta2 + Evt13 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt13: Receive A-RELEASE-RP PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
         pass
 
     def test_evt14(self):
+        """Test Sta2 + Evt14."""
         # Sta2 + Evt14 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt15(self):
+        """Test Sta2 + Evt15."""
         # Sta2 + Evt15 -> <ignore> -> Sta2
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt15: Receive A-ABORT (rq) primitive from <local user>
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         pass
 
     def test_evt16(self):
+        """Test Sta2 + Evt16."""
         # Sta2 + Evt16 -> AA-2 -> Sta1
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt16: Receive A-ABORT PDU from <remote>
-        # AA-2: Stop ARTIM
-        #       Send CONNECTION_CLOSE to <transport service>
-        # Sta1: Idle
         pass
 
     def test_evt17(self):
+        """Test Sta2 + Evt17."""
         # Sta2 + Evt17 -> AA-5 -> Sta1
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt17: Receive TRANSPORT_CLOSED from <transport service>
-        # AA-5: Stop ARTIM
-        # Sta1: Idle
         pass
 
     def test_evt18(self):
+        """Test Sta2 + Evt18."""
         # Sta2 + Evt18 -> AA-2 -> Sta1
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt18: ARTIM timer expired from <local service>
-        # AA-2: Stop ARTIM
-        #       Send CONNECTION_CLOSE to <transport service>
-        # Sta1: Idle
         pass
 
     def test_evt19(self):
+        """Test Sta2 + Evt19."""
         # Sta2 + Evt19 -> AA-1 -> Sta13
-        # Sta2: Connection open, awaiting A-ASSOCIATE-RQ from <remote>
         # Evt19: Received unrecognised or invalid PDU from <remote>
-        # AA-1: Send A-ABORT PDU from <local service> to <remote>
-        #       Restart ARTIM
-        # Sta13: Awaiting TRANSPORT_CLOSE from <transport service>
         pass
 
 
@@ -2568,7 +2436,6 @@ class TestState05(TestStateBase):
 
         time.sleep(0.3)
 
-        #self.assoc.acse.send_abort(self.assoc, 0x00)
         self.assoc.dul.send_pdu(self.get_associate('accept'))
 
         time.sleep(0.2)
@@ -2916,6 +2783,1311 @@ class TestState05(TestStateBase):
         assert self.fsm._events[:3] == ['Evt1', 'Evt2', 'Evt19']
         # Issue A-ABORT PDU
         assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+
+class TestState06(TestStateBase):
+    """Tests for State 06: Association established and ready for data."""
+    def test_evt01(self):
+        """Test Sta6 + Evt1."""
+        # Sta6 + Evt1 -> <ignore> -> Sta6
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.4, 'shutdown'])
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.3)
+
+        self.assoc.dul.send_pdu(self.get_associate('request'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt1']
+
+    @pytest.mark.skip()
+    def test_evt02(self):
+        """Test Sta6 + Evt2."""
+        # Sta6 + Evt2 -> <ignore> -> Sta6
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta6 + Evt3."""
+        # Sta6 + Evt3 -> AA-8 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(a_associate_ac)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt3', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta13']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt3']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+    def test_evt04(self):
+        """Test Sta6 + Evt4."""
+        # Sta6 + Evt4 -> AA-8 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(a_associate_rj)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt4', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta13']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt4']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+    @pytest.mark.skip()
+    def test_evt05(self):
+        """Test Sta6 + Evt5."""
+        # Sta6 + Evt5 -> <ignore> -> Sta6
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta6 + Evt6."""
+        # Sta6 + Evt6 -> AA-8 -> Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(a_associate_rq)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt6', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta13']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt6']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+    def test_evt07(self):
+        """Test Sta6 + Evt7."""
+        # Sta6 + Evt7 -> <ignore> -> Sta6
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.3])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_associate('accept'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt7']
+
+    def test_evt08(self):
+        """Test Sta6 + Evt8."""
+        # Sta6 + Evt8 -> <ignore> -> Sta6
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.3])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_associate('reject'))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt8']
+
+    def test_evt09(self):
+        """Test Sta6 + Evt9."""
+        # Sta6 + Evt9 -> DT-1 -> Sta6
+        # Evt9: Receive P-DATA primitive from <local user>
+        # DT-1: Send P-DATA-TD PDU
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_pdata())
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt9', 'DT-1'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt9']
+
+    def test_evt10(self):
+        """Test Sta6 + Evt10."""
+        # Sta6 + Evt10 -> DT-2 -> Sta6
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        # DT-2: Send P-DATA primitive
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', p_data_tf])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt10', 'DT-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt10']
+
+    def test_evt11(self):
+        """Test Sta6 + Evt11."""
+        # Sta6 + Evt11 -> AR-1 -> Sta7
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.3])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(False))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt11']
+
+    def test_evt12(self):
+        """Test Sta6 + Evt12."""
+        # Sta6 + Evt12 -> AR-2 -> Sta8
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        # AR-2: Issue A-RELEASE (rq) primitive
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(a_release_rq)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt12', 'AR-2'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta8']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt12']
+
+    def test_evt13(self):
+        """Test Sta6 + Evt13."""
+        # Sta6 + Evt13 -> AA-8 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(a_release_rp)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt13', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta13']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt13']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+    def test_evt14(self):
+        """Test Sta6 + Evt14."""
+        # Sta6 + Evt14 -> <ignore> -> Sta6
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['wait', 0.3])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.dul.send_pdu(self.get_release(True))
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt14']
+
+    def test_evt15(self):
+        """Test Sta6 + Evt15."""
+        # Sta6 + Evt15 -> AA-1 -> Sta13
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        # AA-1: Send A-ABORT PDU and start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(None)
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        self.assoc.abort()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:3] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+        ]
+        assert self.fsm._transitions[:3] == ['Sta4', 'Sta5', 'Sta6']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt15']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x00\x00'
+
+    def test_evt16(self):
+        """Test Sta6 + Evt16."""
+        # Sta6 + Evt16 -> AA-3 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        # AA-3: Issue A-ABORT or A-P-ABORT, and close connection
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(['skip', a_abort])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt16', 'AA-3'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta1']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt16']
+
+    def test_evt17(self):
+        """Test Sta6 + Evt17."""
+        # Sta6 + Evt17 -> AA-4 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        # AA-4: Issue A-P-ABORT primitive
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt17', 'AA-4'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta1']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt17']
+
+    @pytest.mark.skip
+    def test_evt18(self):
+        """Test Sta6 + Evt18."""
+        # Sta6 + Evt18 -> <ignore> -> Sta6
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta6 + Evt19."""
+        # Sta6 + Evt19 -> AA-8 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        # AA-8: Send A-ABORT PDU, issue A-P-ABORT primitive, start ARTIM
+        scp = DummyAE()
+        scp.mode = 'acceptor'
+        scp.queue.put(None)
+        scp.queue.put(['skip', a_associate_ac])
+        scp.queue.put(b'\x08\x00\x00\x00\x00')
+        scp.queue.put('shutdown')
+        scp.start()
+
+        self.assoc.start()
+
+        time.sleep(0.2)
+
+        assert self.fsm._changes[:4] == [
+            ('Sta1', 'Evt1', 'AE-1'),
+            ('Sta4', 'Evt2', 'AE-2'),
+            ('Sta5', 'Evt3', 'AE-3'),
+            ('Sta6', 'Evt19', 'AA-8'),
+        ]
+        assert self.fsm._transitions[:4] == ['Sta4', 'Sta5', 'Sta6', 'Sta13']
+        assert self.fsm._events[:4] == ['Evt1', 'Evt2', 'Evt3', 'Evt19']
+
+        # Issue A-ABORT PDU
+        assert scp.received[1] == b'\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00'
+
+
+@pytest.mark.skip()
+class TestState07(TestStateBase):
+    """Tests for State 07: """
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState08(TestStateBase):
+    """Tests for State 08: """
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState09(TestStateBase):
+    """Tests for State 09: """
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState10(TestStateBase):
+    """Tests for State 10: ."""
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState11(TestStateBase):
+    """Tests for State 11: ."""
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState12(TestStateBase):
+    """Tests for State 12: """
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
+
+
+@pytest.mark.skip()
+class TestState13(TestStateBase):
+    """Tests for State 13:"""
+    def test_evt01(self):
+        """Test Sta2 + Evt1."""
+        # Sta2 + Evt1 -> <ignore> -> Sta2
+        # Evt1: A-ASSOCIATE (rq) primitive from <local user>
+        pass
+
+    def test_evt02(self):
+        """Test Sta2 + Evt2."""
+        # Sta2 + Evt2 -> <ignore> -> Sta2
+        # Evt2: Receive TRANSPORT_OPEN from <transport service>
+        pass
+
+    def test_evt03(self):
+        """Test Sta2 + Evt3."""
+        # Sta2 + Evt3 -> AA-1 -> Sta13
+        # Evt3: Receive A-ASSOCIATE-AC PDU from <remote>
+        pass
+
+    def test_evt04(self):
+        """Test Sta2 + Evt4."""
+        # Sta2 + Evt4 -> AA-1 -> Sta13
+        # Evt4: Receive A-ASSOCIATE-RJ PDU from <remote>
+        pass
+
+    def test_evt05(self):
+        """Test Sta2 + Evt5."""
+        # Sta2 + Evt5 -> <ignore> -> Sta2
+        # Evt5: Receive TRANSPORT_INDICATION from <transport service>
+        pass
+
+    def test_evt06(self):
+        """Test Sta2 + Evt6."""
+        # Sta2 + Evt6 -> AE-6 -> Sta3 or Sta13
+        # Evt6: Receive A-ASSOCIATE-RQ PDU from <remote>
+        pass
+
+    def test_evt07(self):
+        """Test Sta2 + Evt7."""
+        # Sta2 + Evt7 -> <ignore> -> Sta2
+        # Evt7: Receive A-ASSOCIATE (accept) primitive from <local user>
+        pass
+
+    def test_evt08(self):
+        """Test Sta2 + Evt8."""
+        # Sta2 + Evt8 -> <ignore> -> Sta2
+        # Evt8: Receive A-ASSOCIATE (reject) primitive from <local user>
+        pass
+
+    def test_evt09(self):
+        """Test Sta2 + Evt9."""
+        # Sta2 + Evt9 -> <ignore> -> Sta2
+        # Evt9: Receive P-DATA primitive from <local user>
+        pass
+
+    def test_evt10(self):
+        """Test Sta2 + Evt10."""
+        # Sta2 + Evt10 -> AA-1 -> Sta13
+        # Evt10: Receive P-DATA-TF PDU from <remote>
+        pass
+
+    def test_evt11(self):
+        """Test Sta2 + Evt11."""
+        # Sta2 + Evt11 -> <ignore> -> Sta2
+        # Evt11: Receive A-RELEASE (rq) primitive from <local user>
+        pass
+
+    def test_evt12(self):
+        """Test Sta2 + Evt12."""
+        # Sta2 + Evt12 -> AA-1 -> Sta13
+        # Evt12: Receive A-RELEASE-RQ PDU from <remote>
+        pass
+
+    def test_evt13(self):
+        """Test Sta2 + Evt13."""
+        # Sta2 + Evt13 -> AA-1 -> Sta13
+        # Evt13: Receive A-RELEASE-RP PDU from <remote>
+        pass
+
+    def test_evt14(self):
+        """Test Sta2 + Evt14."""
+        # Sta2 + Evt14 -> <ignore> -> Sta2
+        # Evt14: Receive A-RELEASE (rsp) primitive from <local user>
+        pass
+
+    def test_evt15(self):
+        """Test Sta2 + Evt15."""
+        # Sta2 + Evt15 -> <ignore> -> Sta2
+        # Evt15: Receive A-ABORT (rq) primitive from <local user>
+        pass
+
+    def test_evt16(self):
+        """Test Sta2 + Evt16."""
+        # Sta2 + Evt16 -> AA-2 -> Sta1
+        # Evt16: Receive A-ABORT PDU from <remote>
+        pass
+
+    def test_evt17(self):
+        """Test Sta2 + Evt17."""
+        # Sta2 + Evt17 -> AA-5 -> Sta1
+        # Evt17: Receive TRANSPORT_CLOSED from <transport service>
+        pass
+
+    def test_evt18(self):
+        """Test Sta2 + Evt18."""
+        # Sta2 + Evt18 -> AA-2 -> Sta1
+        # Evt18: ARTIM timer expired from <local service>
+        pass
+
+    def test_evt19(self):
+        """Test Sta2 + Evt19."""
+        # Sta2 + Evt19 -> AA-1 -> Sta13
+        # Evt19: Received unrecognised or invalid PDU from <remote>
+        pass
 
 
 class TestStateMachineFunctionalRequestor(object):


### PR DESCRIPTION
* Improve unit test coverage (both functional and non-functional) of the FSM
* Fix bug in AA_7
* Change network_timeout default to 60 s
* Acceptor no longer aborts if no accepted presentation contexts

#### Tasks
 - [x] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Unit tests passing after adding fix/feature
