### PR TITLE
[MRG] Add Event.move_destination, fix example

### DIFF
--- a/docs/examples/qr_move.rst
+++ b/docs/examples/qr_move.rst
@@ -187,17 +187,16 @@ to see the requirements for the ``evt.EVT_C_MOVE`` handler.
             yield 0xC000, None
             return
 
-        # Check move_aet is known
         # get_known_aet() is here to represent a user-implemented method of
-        #   getting known AEs
+        #   getting known AEs, for this example it returns a dict with the
+        #   AE titles as keys
         known_aet_dict = get_known_aet()
-        if move_aet not in known_aet_dict:
+        try:
+            (addr, port) = known_aet_dict[event.move_destination]
+        except KeyError:
             # Unknown destination AE
             yield (None, None)
             return
-
-        # Assuming known_ae_dict is {b'STORE_SCP       ' : ('127.0.0.1', 11113)}
-        (addr, port) = known_ae_dict[move_ae]
 
         # Yield the IP address and listen port of the destination AE
         yield (addr, port)
@@ -220,7 +219,7 @@ to see the requirements for the ``evt.EVT_C_MOVE`` handler.
         # Skip the other QR levels...
 
         # Yield the total number of C-STORE sub-operations required
-        yield len(instances)
+        yield len(matching)
 
         # Yield the matching instances
         for instance in matching:

--- a/pynetdicom/_handlers.py
+++ b/pynetdicom/_handlers.py
@@ -2431,8 +2431,9 @@ def doc_handle_move(event):
           that is running the service that received the C-MOVE request.
         * ``context`` : the presentation context the request was sent under
           as a ``presentation.PresentationContextTuple``.
-        * ``description`` : a description of the event that occurred as str.
-        * ``name`` : the name of the event that occurred as str.
+        * ``description`` : a description of the event that occurred as
+          ``str``.
+        * ``name`` : the name of the event that occurred as ``str``.
         * ``request`` : the received
           :py:class:`C-MOVE request <pynetdicom.dimse_primitives.C_MOVE>`
         * ``timestamp`` : the
@@ -2447,9 +2448,11 @@ def doc_handle_move(event):
           a deferred read when decoding data, if the decode fails the returned
           ``Dataset`` will only raise an exception at the time of use.
         * ``is_cancelled`` : returns ``True`` if a
-          C-CANCEL request has been received, False otherwise. If a C-CANCEL
-          is received then the handler should yield a ``(0xFE00, None)``
-          status/dataset pair and return.
+          C-CANCEL request has been received, ``False`` otherwise. If a
+          C-CANCEL is received then the handler should yield a ``(0xFE00,
+          None)`` status/dataset pair and return.
+        * ``move_destination`` : returns the request's (0000,0600) *Move
+          Destination* AE title as a length 16 ``bytes``.
 
     Yields
     ------

--- a/pynetdicom/events.py
+++ b/pynetdicom/events.py
@@ -253,8 +253,9 @@ class Event(object):
         Returns
         -------
         list of pydicom.tag.Tag
-            The *Attribute Identifier List* tags, may be an empty list if no
-            *Attribute Identifier List* was included in the C-GET request.
+            The (0000,1005) *Attribute Identifier List* tags, may be an empty
+            list if no *Attribute Identifier List* was included in the C-GET
+            request.
 
         Raises
         ------
@@ -548,6 +549,29 @@ class Event(object):
             "'Modification List' parameter"
         )
         return self._get_dataset("ModificationList", msg)
+
+    @property
+    def move_destination(self):
+        """Return a C-MOVE request's `Move Destination` as bytes.
+
+        Returns
+        -------
+        bytes
+            The request's (0000,0600) *Move Destination* value as length 16
+            bytes (including trailing spaces as padding if required).
+
+        Raises
+        ------
+        AttributeError
+            If the corresponding event is not a C-MOVE request.
+        """
+        try:
+            return self.request.MoveDestination
+        except AttributeError:
+            raise AttributeError(
+                "The corresponding event is not a C-MOVE request and has no "
+                "'Move Destination' parameter"
+            )
 
     @property
     def name(self):

--- a/pynetdicom/tests/test_events.py
+++ b/pynetdicom/tests/test_events.py
@@ -124,6 +124,13 @@ class TestEvent(object):
             event.identifier
 
         msg = (
+            r"The corresponding event is not a C-MOVE request "
+            r"and has no 'Move Destination' parameter"
+        )
+        with pytest.raises(AttributeError, match=msg):
+            event.move_destination
+
+        msg = (
             r"The corresponding event is not an N-ACTION request and has no "
             r"'Action Information' parameter"
         )


### PR DESCRIPTION
#### Reference issue
* Adds `Event.move_destination` property for C-MOVE requests
* Fix for QR Move example (closes #349)

#### Tasks
 - [x] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Documentation and examples updated (if relevant)
 - [x] Unit tests passing and coverage at 100% after adding fix/feature
