### PR TITLE
[MRG] Add checkpoint to association reactor

### DIFF
--- a/docs/changelog/v1.4.0.rst
+++ b/docs/changelog/v1.4.0.rst
@@ -11,13 +11,16 @@ Fixes
   if no matches were yielded by the C-FIND request handler.
 * Fixed association being aborted due to failure to decode a rejected
   presentation context when the transfer syntax value is empty (:issue:`342`)
-
+* Checkpoint added to the reactor in ``Association`` to prevent a possible
+  race condition when acting as the Acceptor and calling one of the
+  ``Association.send_*()`` methods.
 
 Enhancements
 ............
 
 * Added support for Protocol Approval Query Retrieve service class
   (:issue:`327`)
+* Added ``Event.move_destination`` property
 
 
 
@@ -33,4 +36,4 @@ Changes
     ``AE.on_association_released()``, ``AE.on_association_aborted()``,
   * ``_config.DECODE_STORE_DATASETS``
   * ``DIMSEServiceProvider.on_send_dimse_message()``,
-    ``DIMSEServiceProvider.on_receive_dimse_message()``,
+    ``DIMSEServiceProvider.on_receive_dimse_message()``

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -172,6 +172,9 @@ class Association(threading.Thread):
         self._started_dul = False
         # Used to pause the association reactor until the DUL is ready
         self._dul_ready = threading.Event()
+        # Used to pause the association reactor while a service is being used
+        self._reactor_checkpoint = threading.Event()
+        self._reactor_checkpoint.set()
 
         # Thread setup
         threading.Thread.__init__(self)
@@ -500,7 +503,6 @@ class Association(threading.Thread):
             self._started_dul = True
             # Wait until the DUL is up and running
             self._dul_ready.wait()
-            #time.sleep(0.05)
 
         if self.is_acceptor:
             primitive = self.dul.receive_pdu(wait=True,
@@ -544,6 +546,13 @@ class Association(threading.Thread):
             If timed out then kill thread
         """
         while not self._kill:
+            # A race condition may occur if the Acceptor uses the send_*()
+            #   methods as the received DIMSE message may be taken off the
+            #   queue before the send_*() method gets to it, so we allow
+            #   the reactor to be paused
+            # Will block until `_reactor_checkpoint` is True
+            self._reactor_checkpoint.wait()
+
             time.sleep(0.001)
 
             # Check with the DIMSE provider to see if a completely decoded
@@ -643,6 +652,10 @@ class Association(threading.Thread):
         """Run the association as the requestor."""
         # Listen for further messages from the peer
         while not self._kill:
+            # For symmetry with `_run_as_acceptor`, but not really needed
+            # Will block until `_reactor_checkpoint` is True
+            self._reactor_checkpoint.wait()
+
             time.sleep(0.1)
 
             # Check for release request
@@ -922,8 +935,15 @@ class Association(threading.Thread):
 
         # Send C-ECHO request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Echo Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(primitive, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -1167,6 +1187,9 @@ class Association(threading.Thread):
             LOGGER.info(elem)
         LOGGER.info('')
 
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         # Send C-FIND request to the peer via DIMSE
         self.dimse.send_msg(req, context.context_id)
 
@@ -1393,6 +1416,9 @@ class Association(threading.Thread):
             LOGGER.info(elem)
         LOGGER.info('')
 
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         # Send C-GET request to the peer via DIMSE
         self.dimse.send_msg(req, context.context_id)
 
@@ -1606,6 +1632,9 @@ class Association(threading.Thread):
             LOGGER.info(elem)
         LOGGER.info('')
 
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         # Send C-MOVE request to the peer via DIMSE and wait for the response
         self.dimse.send_msg(req, context.context_id)
 
@@ -1779,9 +1808,15 @@ class Association(threading.Thread):
             LOGGER.error("Failed to encode the supplied Dataset")
             raise ValueError('Failed to encode the supplied Dataset')
 
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         # Send C-STORE request to the peer via DIMSE and wait for the response
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -1825,6 +1860,7 @@ class Association(threading.Thread):
                     LOGGER.error("Connection closed or timed-out")
                     self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             if not isinstance(rsp, C_FIND):
@@ -1834,6 +1870,7 @@ class Association(threading.Thread):
                 )
                 self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             if not rsp.is_valid_response:
@@ -1842,6 +1879,7 @@ class Association(threading.Thread):
                 )
                 self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             # Status may be 'Failure', 'Cancel', 'Warning', 'Success'
@@ -1900,6 +1938,9 @@ class Association(threading.Thread):
             yield status, identifier
             break
 
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
+
     def _wrap_get_move_responses(self, transfer_syntax):
         """Wrapper for the C-GET/C-MOVE response generators.
 
@@ -1934,6 +1975,7 @@ class Association(threading.Thread):
                     LOGGER.error("Connection closed or timed-out")
                     self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             if not isinstance(rsp, (C_STORE, C_GET, C_MOVE)):
@@ -1943,6 +1985,7 @@ class Association(threading.Thread):
                 )
                 self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             if isinstance(rsp, C_STORE):
@@ -1958,6 +2001,7 @@ class Association(threading.Thread):
                 )
                 self.abort()
                 yield Dataset(), None
+                self._reactor_checkpoint.set()
                 return
 
             # Status may be 'Failure', 'Cancel', 'Warning', 'Success'
@@ -2033,6 +2077,9 @@ class Association(threading.Thread):
             #   or Cancel
             yield status, identifier
             break
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
     # DIMSE-N services provided by the Association
     def send_n_action(self, dataset, action_type, class_uid, instance_uid,
@@ -2147,8 +2194,15 @@ class Association(threading.Thread):
 
         # Send N-ACTION request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Action Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -2335,8 +2389,15 @@ class Association(threading.Thread):
 
         # Send N-CREATE request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Create Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -2454,8 +2515,15 @@ class Association(threading.Thread):
 
         # Send N-DELETE request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Delete Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -2586,8 +2654,15 @@ class Association(threading.Thread):
         # Send N-EVENT-REPORT request to the peer via DIMSE and wait for
         # the response primitive
         LOGGER.info('Sending Event Report Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -2748,8 +2823,15 @@ class Association(threading.Thread):
 
         # Send N-GET request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Get Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:
@@ -2950,8 +3032,15 @@ class Association(threading.Thread):
 
         # Send N-SET request to the peer via DIMSE and wait for the response
         LOGGER.info('Sending Set Request: MsgID {}'.format(msg_id))
+
+        # Pause the reactor to prevent a race condition
+        self._reactor_checkpoint.clear()
+
         self.dimse.send_msg(req, context.context_id)
         cx_id, rsp = self.dimse.get_msg(block=True)
+
+        # Unpause the reactor
+        self._reactor_checkpoint.set()
 
         # If `rsp` is None then the DIMSE timeout expired so abort
         if rsp is None:


### PR DESCRIPTION
#### Reference issue
When acting as the association acceptor there's a race condition between the reactor and the send_* methods when processing the response to the DIMSE request. In order to fix this a checkpoint is added to the reactor which enables it to be paused

#### Tasks
 - [x] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Unit tests passing and coverage at 100% after adding fix/feature
