### PR TITLE
[MRG] Add meta_uid keyword parameter to Association send_n_*() methods

### DIFF
--- a/docs/changelog/v1.4.0.rst
+++ b/docs/changelog/v1.4.0.rst
@@ -22,6 +22,11 @@ Enhancements
 * Added support for Protocol Approval Query Retrieve service class
   (:issue:`327`)
 * Added ``Event.move_destination`` property
+* Added ``meta_uid`` keyword parameters to the ``Association.send_n_*()``
+  methods to allow the use of Meta SOP Classes (such as those used in the
+  Print Management service class)
+* Added *Basic Grayscale Print Management Meta SOP Class* and *Basic Color
+  Print Management Meta SOP Class* to ``sop_class``.
 
 
 Changes

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -2124,7 +2124,7 @@ class Association(threading.Thread):
 
     # DIMSE-N services provided by the Association
     def send_n_action(self, dataset, action_type, class_uid, instance_uid,
-                      msg_id=1):
+                      msg_id=1, meta_uid=None):
         """Send an N-ACTION request message to the peer AE.
 
         Parameters
@@ -2143,6 +2143,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -2205,7 +2212,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
         transfer_syntax = context.transfer_syntax[0]
 
         # Build N-ACTION request primitive
@@ -2281,7 +2288,8 @@ class Association(threading.Thread):
 
         return status, action_reply
 
-    def send_n_create(self, dataset, class_uid, instance_uid=None, msg_id=1):
+    def send_n_create(self, dataset, class_uid, instance_uid=None, msg_id=1,
+                      meta_uid=None):
         """Send an N-CREATE request message to the peer AE.
 
         Parameters
@@ -2298,6 +2306,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -2402,7 +2417,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
         transfer_syntax = context.transfer_syntax[0]
 
         # Build N-CREATE request primitive
@@ -2477,7 +2492,7 @@ class Association(threading.Thread):
 
         return status, attribute_list
 
-    def send_n_delete(self, class_uid, instance_uid, msg_id=1):
+    def send_n_delete(self, class_uid, instance_uid, msg_id=1, meta_uid=None):
         """Send an N-DELETE request message to the peer AE.
 
         Parameters
@@ -2491,6 +2506,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -2543,7 +2565,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
 
         # Build N-DELETE request primitive
         #   (M) Message ID
@@ -2579,7 +2601,7 @@ class Association(threading.Thread):
         return status
 
     def send_n_event_report(self, dataset, event_type, class_uid,
-                            instance_uid, msg_id=1):
+                            instance_uid, msg_id=1, meta_uid=None):
         """Send an N-EVENT-REPORT request message to the peer AE.
 
         Parameters
@@ -2600,6 +2622,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -2661,8 +2690,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        transfer_syntax = None
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
 
         # Build N-EVENT-REPORT request primitive
         #   (M) Message ID
@@ -2741,7 +2769,8 @@ class Association(threading.Thread):
 
         return status, event_reply
 
-    def send_n_get(self, identifier_list, class_uid, instance_uid, msg_id=1):
+    def send_n_get(self, identifier_list, class_uid, instance_uid, msg_id=1,
+                   meta_uid=None):
         """Send an N-GET request message to the peer AE.
 
         Parameters
@@ -2760,6 +2789,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -2848,7 +2884,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
         transfer_syntax = context.transfer_syntax[0]
 
         # Build N-GET request primitive
@@ -2911,7 +2947,8 @@ class Association(threading.Thread):
 
         return status, attribute_list
 
-    def send_n_set(self, dataset, class_uid, instance_uid, msg_id=1):
+    def send_n_set(self, dataset, class_uid, instance_uid, msg_id=1,
+                   meta_uid=None):
         """Send an N-SET request message to the peer AE.
 
         Parameters
@@ -2928,6 +2965,13 @@ class Association(threading.Thread):
         msg_id : int, optional
             The request's *Message ID* parameter value, must be between 0 and
             65535, inclusive, (default 1).
+        meta_uid : pydicom.uid.UID, optional
+            If the service class operates under a presentation context
+            negotiated using a *Meta SOP Class* rather than a standard *SOP
+            Class* (such as with *Print Management* service class and its
+            *Basic Grayscale Print Management Meta SOP Class*) then this
+            value will be used to determine the corresponding presentation
+            context.
 
         Returns
         -------
@@ -3045,7 +3089,7 @@ class Association(threading.Thread):
 
         # Determine the Presentation Context we are operating under
         #   and hence the transfer syntax to use for encoding `dataset`
-        context = self._get_valid_context(class_uid, '', 'scu')
+        context = self._get_valid_context(meta_uid or class_uid, '', 'scu')
         transfer_syntax = context.transfer_syntax[0]
 
         # Build N-SET request primitive

--- a/pynetdicom/sop_class.py
+++ b/pynetdicom/sop_class.py
@@ -339,10 +339,12 @@ _PRINT_MANAGEMENT_CLASSES = {
     'BasicFilmBoxSOPClass' : '1.2.840.10008.5.1.1.2',
     'BasicGrayscaleImageBoxSOPClass' : '1.2.840.10008.5.1.1.4',
     'BasicColourImageBoxSOPClass' : '1.2.840.10008.5.1.1.4.1',
+    'BasicGrayscalePrintManagementMetaSOPClass' : '1.2.840.10008.5.1.1.9',
     'PrintJobSOPClass' : '1.2.840.10008.5.1.1.14',
     'BasicAnnotationBoxSOPClass' : '1.2.840.10008.5.1.1.15',
     'PrinterSOPClass' : '1.2.840.10008.5.1.1.16',
     'PrinterConfigurationRetrievalSOPClass' : '1.2.840.10008.5.1.1.16.376',
+    'BasicColorPrintManagementMetaSOPClass' : '1.2.840.10008.5.1.1.18',
     'PresentationLUTSOPClass' : '1.2.840.10008.5.1.1.23',
 }
 

--- a/pynetdicom/tests/test_assoc_n.py
+++ b/pynetdicom/tests/test_assoc_n.py
@@ -21,6 +21,8 @@ from pynetdicom.sop_class import (
     ModalityPerformedProcedureStepNotificationSOPClass,
     ModalityPerformedProcedureStepRetrieveSOPClass,
     ModalityPerformedProcedureStepSOPClass,
+    BasicGrayscalePrintManagementMetaSOPClass,
+    PrinterSOPClass,
 )
 from pynetdicom.service_class import ServiceClass
 
@@ -477,6 +479,46 @@ class TestAssociationSendNEventReport(object):
 
         scp.shutdown()
 
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)
+
 
 class TestAssociationSendNGet(object):
     """Run tests on Assocation send_n_get."""
@@ -867,6 +909,46 @@ class TestAssociationSendNGet(object):
         assert assoc.is_released
 
         scp.shutdown()
+
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)
 
 
 class TestAssociationSendNSet(object):
@@ -1302,6 +1384,46 @@ class TestAssociationSendNSet(object):
 
         scp.shutdown()
 
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)
+
 
 # TODO: Refactor when N-ACTION SCP is implemented
 class TestAssociationSendNAction(object):
@@ -1734,6 +1856,46 @@ class TestAssociationSendNAction(object):
 
         scp.shutdown()
 
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)
+
 
 class TestAssociationSendNCreate(object):
     """Run tests on Assocation send_n_create."""
@@ -2150,6 +2312,46 @@ class TestAssociationSendNCreate(object):
 
         scp.shutdown()
 
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)
+
 
 # TODO: Refactor when N-DELETE SCP is implemented
 class TestAssociationSendNDelete(object):
@@ -2428,3 +2630,43 @@ class TestAssociationSendNDelete(object):
         assert assoc.is_released
 
         scp.shutdown()
+
+    @pytest.mark.skip(reason="Needs print management service")
+    def test_meta_uid(self):
+        """Test using a Meta SOP Class"""
+        recv = []
+
+        def handle(event):
+            recv.append(event)
+            return 0x0000, event.event_information
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(BasicGrayscalePrintManagementMetaSOPClass)
+        scp = ae.start_server(
+            ('', 11112), block=False,
+            evt_handlers=[(evt.EVT_N_EVENT_REPORT, handle)]
+        )
+
+        ae.add_requested_context(BasicGrayscalePrintManagementMetaSOPClass)
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+
+        ds = Dataset()
+        ds.PatientName = 'Test^test'
+        status, ds = assoc.send_n_event_report(
+            ds, 1,
+            PrinterSOPClass,
+            '1.2.840.10008.5.1.1.40.1',
+            meta_uid=BasicGrayscalePrintManagementMetaSOPClass
+        )
+        assert status.Status == 0x0000
+        assert ds.PatientName == 'Test^test'
+        assoc.release()
+        assert assoc.is_released
+
+        scp.shutdown()
+
+        print(recv)


### PR DESCRIPTION
#### Reference issue
Allows the use of Meta SOP Classes with the `Association.send_n_*()` methods, as required by the Print Management service class

#### Tasks
 - [x] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Documentation and examples updated (if relevant)
 - [x] Unit tests passing and coverage at 100% after adding fix/feature
