### PR TITLE
Fix list style, remove sphinx built source code

### DIFF
--- a/docs/_static/css/pynetdicom.css
+++ b/docs/_static/css/pynetdicom.css
@@ -83,3 +83,7 @@ code.xref {
     color: #2980B9 !important;
     font-size: 80%;
 }
+
+p.first {
+    margin-bottom: 0px !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,7 +65,7 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.imgmath',
     'sphinx.ext.ifconfig',
-    'sphinx.ext.viewcode',
+    #'sphinx.ext.viewcode',
     #'sphinx_gallery.gen_gallery',
     'sphinx.ext.autosummary',
     'sphinx.ext.napoleon',
@@ -228,7 +228,7 @@ html_static_path = ['_static']
 # html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-# html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, an OpenSearch description file will be output, and all pages will
 # contain a <link> tag referring to it.  The value of this option must be the


### PR DESCRIPTION
Fix the bottom padding on sub-lists, sphinx no longer builds its own copy of the source code (and link to sphinx built source code removed from API docs).
