### PR TITLE
Typo in C_GET SCP example

### DIFF
--- a/docs/examples/qr_get.rst
+++ b/docs/examples/qr_get.rst
@@ -218,7 +218,7 @@ Check the
             # Pending
             yield (0xFF00, instance)
 
-    handlers = [(evt.EVT_C_GET), handle_get]
+    handlers = [(evt.EVT_C_GET, handle_get)]
 
     # Create application entity
     ae = AE()


### PR DESCRIPTION
Noticed this typo while trying out the examples.

When executed, it would crash with:

```AttributeError: 'str' object has no attribute 'is_notification'```

Making the handler a tuple fixes it.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
The issue describing the bug or feature that this PR addresses.

#### Tasks
 - [ ] Unit tests added that reproduce issue or prove feature is working
 - [x] Fix or feature added
 - [x] Documentation and examples updated (if relevant)
 - [x] Unit tests passing and coverage at 100% after adding fix/feature
 - [ ] Apps updated and tested (if relevant)
