### PR TITLE
[MRG] StopTravis adding enum support for Python 2.7

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    pynetdicom/tests/*
+    pynetdicom/apps/*
+    pydicom/*
+    pydicom-master/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           python: "3.8"
           env: TEST_SUITE=pydicom_master
         - name: "Python 2.7, pydicom release"
-          python: "2.7"
+          python: "2.7.14"
           env: TEST_SUITE=pydicom_release
         - name: "Python 3.5, pydicom release"
           python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ matrix:
           python: "3.8"
           env: TEST_SUITE=pydicom_master
         - name: "Python 2.7, pydicom release"
-          python: "2.7.14"
+          python: "2.7"
           env: TEST_SUITE=pydicom_release
         - name: "Python 3.5, pydicom release"
           python: "3.5"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,12 @@ matrix:
           env: TEST_SUITE=pydicom_release
 
 # Install dependencies and pynetdicom
-install: source build_tools/travis/install.sh
+install:
+    - source build_tools/travis/install.sh
 
 # Command to run tests
 script:
-    - pytest --cov=pynetdicom --pyargs pynetdicom --ignore=pydicom-master,pydicom --ignore=pynetdicom/apps
+    - python -m pytest --cov pynetdicom
 
 after_success:
     # Upload coverage results to codecov.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,11 @@ matrix:
 # Install dependencies and pynetdicom
 install:
     - source build_tools/travis/install.sh
+    - python -m pip install .
 
 # Command to run tests
 script:
-    - python -m pytest --cov pynetdicom
+    - python -m pytest --cov pynetdicom --ignore=pynetdicom/apps
 
 after_success:
     # Upload coverage results to codecov.io

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -8,7 +8,7 @@ pip install coverage
 pip install pytest-cov
 pip install -U pytest
 pip install asv
-pip uninstall enum34
+pip uninstall -y enum34
 
 pip list
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -2,10 +2,15 @@
 
 set -e
 
+pip install -U pip
+
 pip install coverage
 pip install pytest-cov
 pip install -U pytest
 pip install asv
+pip uninstall enum34
+
+pip list
 
 echo ""
 echo "Test suite is " $TEST_SUITE

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -4,23 +4,20 @@ set -e
 
 pip install coverage
 pip install pytest-cov
-pip install pytest
+pip install -U pytest
 pip install asv
-#python setup.py install
 
 echo ""
 echo "Test suite is " $TEST_SUITE
 echo ""
 
 if [[ "$TEST_SUITE" == "pydicom_master" ]]; then
-    wget https://github.com/pydicom/pydicom/archive/master.tar.gz -O /tmp/pydicom.tar.gz
-    tar xzf /tmp/pydicom.tar.gz
-    pip install $PWD/pydicom-master
-    python -c "import pydicom; print('pydicom version', pydicom.__version__)"
+    pip install git+https://github.com/pydicom/pydicom.git
 elif [[ "$TEST_SUITE" == "pydicom_release" ]]; then
     pip install pydicom
-    python -c "import pydicom; print('pydicom version', pydicom.__version__)"
 fi
 
 python --version
+python -c "import pydicom; print('pydicom version', pydicom.__version__)"
+python -c "import pytest; print('pytest version', pytest.__version__)"
 python -c "import ssl; print(ssl.OPENSSL_VERSION)"


### PR DESCRIPTION
* Add `.converagerc` file and simplify coverage command
* Uninstall `enum34` package when using Python 2.7

#### Tasks
 - [ ] Unit tests passing and coverage at 100% after adding fix/feature
