### PR TITLE
[WIP] fix: handle SSLSocket buffering

### DIFF
--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -276,7 +276,16 @@ class AssociationSocket(object):
             self.event_queue.put('Evt17')
             return False
 
-        return bool(ready)
+        return (
+            bool(ready)
+            # XXX: An SSLSocket may have buffered data available that `select`
+            # is unaware of.
+            or (
+                _HAS_SSL
+                and isinstance(self.socket, ssl.SSLSocket)
+                and bool(self.socket.pending())
+            )
+        )
 
     def recv(self, nr_bytes):
         """Read `nr_bytes` from the socket.


### PR DESCRIPTION
#### Reference issue

This may be related to / address these issues:

https://github.com/pydicom/pynetdicom/issues/500
https://github.com/pydicom/pynetdicom/issues/364

#### Other references
https://stackoverflow.com/questions/3187565/select-and-ssl-in-python/12133807#12133807
https://docs.python.org/3/library/ssl.html#ssl-nonblocking
https://www.openssl.org/docs/man1.1.0/man3/SSL_pending.html

I had a flaky test locally with pynetdicom sending a C-FIND request as a SCU over TLS. I observed that `select` would fail to indicate that the socket was ready when there was, in fact, data available on the socket from the C-FIND response.

An SSLSocket will buffer data inside OpenSSL's SSL context. `select` doesn't know about this buffer, so it will fail to indicate the socket is ready when data is buffered. 

Marking this as WIP until I can construct a test that exercises this case, though I confirmed locally that this resolves my flaky test.

Aside, it is odd that the above resources imply that this is only a problem with **non-blocking** sockets. I'm not an expert by any means but it doesn't seem relevant.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Apps updated and tested (if relevant)
