### PR TITLE
[MRG] prevent os default timeout on association socket

### DIFF
--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -148,6 +148,7 @@ class AssociationSocket(object):
                 )
             # Try and connect to remote at (address, port)
             #   raises socket.error if connection refused
+            self.socket.settimeout(self._assoc.network_timeout)
             self.socket.connect(address)
             # Trigger event - connection open
             evt.trigger(self.assoc, evt.EVT_CONN_OPEN, {'address' : address})


### PR DESCRIPTION
#### Reference issue
Ive ran into an issue where setting timeouts in pynetdicom doesn't result in these timeouts actually being enforced. This happened when trying to do a simple C-Echo to a destination that drops any traffic (no TCP RST). The timeout seemed to be around 20 secs even though i set the association.network_timeout to 5 seconds.

This commit fixed the behaviour. 

Sry for not providing with a test, couldn't figure out how to put this into a unittest.