### PR TITLE
[MRG] Fix wrong name of used status variable

### DIFF
--- a/pynetdicom/apps/common.py
+++ b/pynetdicom/apps/common.py
@@ -606,8 +606,8 @@ def handle_store(event, args, app_logger):
             app_logger.error(f"    {args.output_directory}")
             app_logger.exception(exc)
             # Failed - Out of Resources - IOError
-            status.Status = 0xA700
-            return status
+            status_ds.Status = 0xA700
+            return status_ds
 
     try:
         if event.context.transfer_syntax == DeflatedExplicitVRLittleEndian:


### PR DESCRIPTION
Only a small fix that is only relevant for exception handling (and did thus probably not yet surface),
nevertheless, for consistency, it should be fixed.