### PR TITLE
[WIP] Improve timeout handling with TLS enabled

### DIFF
--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -214,6 +214,8 @@ class AssociationSocket(object):
                 socket.SO_RCVTIMEO,
                 pack('ll', timeout_seconds, timeout_microsec)
             )
+            # Make timeout visible for ssl
+            sock.settimeout(self.assoc.network_timeout)
 
         sock.bind(address)
 


### PR DESCRIPTION
With TLS/ssl, the timeout will be read from the socket using gettimeout. If we don't set the timeout on the socket using settimeout, the ssl socket will not be configured with the correct timeout. 

This change sets the network timeout to the socket using socket.settimeout.

This helps if the client is sending a C-MOVE request, but is not immediately ready to process the C-MOVE association.

#### Reference issue
N/A because no issue has been raised for this.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Apps updated and tested (if relevant)
