### PR TITLE
[MRG] Small improvements to Apps tests on Windows

### DIFF
--- a/pynetdicom/apps/tests/test_echoscp.py
+++ b/pynetdicom/apps/tests/test_echoscp.py
@@ -27,22 +27,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_echoscp(args):
     """Start the echoscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE, '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_echoscp.py
+++ b/pynetdicom/apps/tests/test_echoscp.py
@@ -45,13 +45,13 @@ def which(program):
 
 def start_echoscp(args):
     """Start the echoscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE, '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_echoscp_cli(args):
     """Start the echoscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'echoscp', '11112'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'echoscp', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 

--- a/pynetdicom/apps/tests/test_echoscu.py
+++ b/pynetdicom/apps/tests/test_echoscu.py
@@ -24,22 +24,6 @@ APP_DIR = os.path.join(os.path.dirname(__file__), '../')
 APP_FILE = os.path.join(APP_DIR, 'echoscu', 'echoscu.py')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_echoscu(args):
     """Start the echoscu.py app and return the process."""
     pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_echoscu.py
+++ b/pynetdicom/apps/tests/test_echoscu.py
@@ -42,14 +42,14 @@ def which(program):
 
 def start_echoscu(args):
     """Start the echoscu.py app and return the process."""
-    pargs = [which('python'), APP_FILE, 'localhost', '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_echoscu_cli(args):
     """Start the echoscu app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'echoscu', 'localhost', '11112'
+        sys.executable, '-m', 'pynetdicom', 'echoscu', 'localhost', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 

--- a/pynetdicom/apps/tests/test_findscu.py
+++ b/pynetdicom/apps/tests/test_findscu.py
@@ -37,22 +37,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_findscu(args):
     """Start the findscu.py app and return the process."""
     pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_findscu.py
+++ b/pynetdicom/apps/tests/test_findscu.py
@@ -55,14 +55,14 @@ def which(program):
 
 def start_findscu(args):
     """Start the findscu.py app and return the process."""
-    pargs = [which('python'), APP_FILE, 'localhost', '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_findscu_scli(args):
     """Start the findscu app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'findscu', 'localhost', '11112'
+        sys.executable, '-m', 'pynetdicom', 'findscu', 'localhost', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 

--- a/pynetdicom/apps/tests/test_getscu.py
+++ b/pynetdicom/apps/tests/test_getscu.py
@@ -55,14 +55,14 @@ def which(program):
 
 def start_getscu(args):
     """Start the getscu.py app and return the process."""
-    pargs = [which('python'), APP_FILE, 'localhost', '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_getscu_cli(args):
     """Start the getscu app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'getscu', 'localhost', '11112'
+        sys.executable, '-m', 'pynetdicom', 'getscu', 'localhost', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 

--- a/pynetdicom/apps/tests/test_getscu.py
+++ b/pynetdicom/apps/tests/test_getscu.py
@@ -37,22 +37,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_getscu(args):
     """Start the getscu.py app and return the process."""
     pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_movescu.py
+++ b/pynetdicom/apps/tests/test_movescu.py
@@ -56,14 +56,14 @@ def which(program):
 
 def start_movescu(args):
     """Start the movescu.py app and return the process."""
-    pargs = [which('python'), APP_FILE, 'localhost', '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_movescu_cli(args):
     """Start the movescu.py app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'movescu', 'localhost', '11112'
+        sys.executable, '-m', 'pynetdicom', 'movescu', 'localhost', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 

--- a/pynetdicom/apps/tests/test_movescu.py
+++ b/pynetdicom/apps/tests/test_movescu.py
@@ -38,22 +38,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_movescu(args):
     """Start the movescu.py app and return the process."""
     pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_qrscp_echo.py
+++ b/pynetdicom/apps/tests/test_qrscp_echo.py
@@ -28,22 +28,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE] + [*args]

--- a/pynetdicom/apps/tests/test_qrscp_echo.py
+++ b/pynetdicom/apps/tests/test_qrscp_echo.py
@@ -46,13 +46,13 @@ def which(program):
 
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE] + [*args]
+    pargs = [sys.executable, APP_FILE] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_qrscp_cli(args):
     """Start the qrscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'qrscp'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'qrscp'] + [*args]
     return subprocess.Popen(pargs)
 
 

--- a/pynetdicom/apps/tests/test_qrscp_find.py
+++ b/pynetdicom/apps/tests/test_qrscp_find.py
@@ -48,19 +48,19 @@ def which(program):
 
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE] + [*args]
+    pargs = [sys.executable, APP_FILE] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_qrscp_cli(args):
     """Start the qrscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'qrscp'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'qrscp'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def _send_datasets():
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
+        sys.executable, '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
         DATA_DIR, '-cx'
     ]
     subprocess.Popen(pargs)

--- a/pynetdicom/apps/tests/test_qrscp_find.py
+++ b/pynetdicom/apps/tests/test_qrscp_find.py
@@ -30,22 +30,6 @@ APP_FILE = os.path.join(APP_DIR, 'qrscp', 'qrscp.py')
 DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE] + [*args]

--- a/pynetdicom/apps/tests/test_qrscp_get.py
+++ b/pynetdicom/apps/tests/test_qrscp_get.py
@@ -49,19 +49,19 @@ def which(program):
 
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE] + [*args]
+    pargs = [sys.executable, APP_FILE] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_qrscp_cli(args):
     """Start the qrscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'qrscp'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'qrscp'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def _send_datasets():
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
+        sys.executable, '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
         DATA_DIR, '-cx'
     ]
     subprocess.Popen(pargs)

--- a/pynetdicom/apps/tests/test_qrscp_get.py
+++ b/pynetdicom/apps/tests/test_qrscp_get.py
@@ -31,22 +31,6 @@ APP_FILE = os.path.join(APP_DIR, 'qrscp', 'qrscp.py')
 DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE] + [*args]

--- a/pynetdicom/apps/tests/test_qrscp_move.py
+++ b/pynetdicom/apps/tests/test_qrscp_move.py
@@ -49,19 +49,19 @@ def which(program):
 
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE] + [*args]
+    pargs = [sys.executable, APP_FILE] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_qrscp_cli(args):
     """Start the qrscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'qrscp'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'qrscp'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def _send_datasets():
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
+        sys.executable, '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
         DATA_DIR, '-cx'
     ]
     subprocess.Popen(pargs)

--- a/pynetdicom/apps/tests/test_qrscp_move.py
+++ b/pynetdicom/apps/tests/test_qrscp_move.py
@@ -31,22 +31,6 @@ APP_FILE = os.path.join(APP_DIR, 'qrscp', 'qrscp.py')
 DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE] + [*args]

--- a/pynetdicom/apps/tests/test_qrscp_store.py
+++ b/pynetdicom/apps/tests/test_qrscp_store.py
@@ -45,19 +45,19 @@ def which(program):
 
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
-    pargs = [which('python'), APP_FILE] + [*args]
+    pargs = [sys.executable, APP_FILE] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_qrscp_cli(args):
     """Start the qrscp app using CLI and return the process."""
-    pargs = [which('python'), '-m', 'pynetdicom', 'qrscp'] + [*args]
+    pargs = [sys.executable, '-m', 'pynetdicom', 'qrscp'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def _send_datasets():
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
+        sys.executable, '-m', 'pynetdicom', 'storescu', 'localhost', '11112',
         DATA_DIR, '-cx'
     ]
     subprocess.Popen(pargs)

--- a/pynetdicom/apps/tests/test_qrscp_store.py
+++ b/pynetdicom/apps/tests/test_qrscp_store.py
@@ -27,22 +27,6 @@ APP_FILE = os.path.join(APP_DIR, 'qrscp', 'qrscp.py')
 DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_qrscp(args):
     """Start the qrscp.py app and return the process."""
     pargs = [sys.executable, APP_FILE] + [*args]

--- a/pynetdicom/apps/tests/test_storescp.py
+++ b/pynetdicom/apps/tests/test_storescp.py
@@ -28,22 +28,6 @@ DATA_DIR = os.path.join(APP_DIR, '../', 'tests', 'dicom_files')
 DATASET_FILE = os.path.join(DATA_DIR, 'CTImageStorage.dcm')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_storescp(args):
     """Start the storescp.py app and return the process."""
     pargs = [sys.executable, APP_FILE, '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_storescp.py
+++ b/pynetdicom/apps/tests/test_storescp.py
@@ -46,14 +46,14 @@ def which(program):
 
 def start_storescp(args):
     """Start the storescp.py app and return the process."""
-    pargs = [which('python'), APP_FILE, '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_storescp_cli(args):
     """Start the storescp app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescp', '11112'
+        sys.executable, '-m', 'pynetdicom', 'storescp', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 

--- a/pynetdicom/apps/tests/test_storescu.py
+++ b/pynetdicom/apps/tests/test_storescu.py
@@ -36,22 +36,6 @@ BE_DATASET_FILE = os.path.join(
 LIB_DIR = os.path.join(APP_DIR, '../')
 
 
-def which(program):
-    # Determine if a given program is installed on PATH
-    def is_exe(fpath):
-        return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
-
-    fpath, fname = os.path.split(program)
-    if fpath:
-        if is_exe(program):
-            return program
-    else:
-        for path in os.environ["PATH"].split(os.pathsep):
-            exe_file = os.path.join(path, program)
-            if is_exe(exe_file):
-                return exe_file
-
-
 def start_storescu(args):
     """Start the storescu.py app and return the process."""
     pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]

--- a/pynetdicom/apps/tests/test_storescu.py
+++ b/pynetdicom/apps/tests/test_storescu.py
@@ -54,14 +54,14 @@ def which(program):
 
 def start_storescu(args):
     """Start the storescu.py app and return the process."""
-    pargs = [which('python'), APP_FILE, 'localhost', '11112'] + [*args]
+    pargs = [sys.executable, APP_FILE, 'localhost', '11112'] + [*args]
     return subprocess.Popen(pargs)
 
 
 def start_storescu_cli(args):
     """Start the storescu app using CLI and return the process."""
     pargs = [
-        which('python'), '-m', 'pynetdicom', 'storescu', 'localhost', '11112'
+        sys.executable, '-m', 'pynetdicom', 'storescu', 'localhost', '11112'
     ] + [*args]
     return subprocess.Popen(pargs)
 


### PR DESCRIPTION
First step towards running apps tests on Windows. On Windows, executables, such as python.exe has the '.exe' postfix. Searching for 'python' in path will therefore fail. Searching for 'python.exe' would work, but by using sys.executable directly, we avoid searching for python on the path alltogether.

Since this is an unit test change only, I do not intend to add tests for the change. I can't guarantee that all apps tests pass, because there are more remaining issues on the Windows platform.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
The issue describing the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Apps updated and tested (if relevant)
