### PR TITLE
[MRG] Fix QR SCP not returning correct status if all subops failed

### DIFF
--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -15,6 +15,8 @@ Fixes
 * Fixed *Composite Instance Retrieve Without Bulk Data Get* SCPs not removing
   *Overlay Data*, *Audio Sample Data* and *Curve Data* bulk data elements
   (:pr:`608`)
+* Fixed not sending a failure response if all C-GET or C-MOVE sub-operations
+  failed when acting as an Query/Retrieve SCP (:issue:`577`)
 
 Enhancements
 ............
@@ -33,9 +35,14 @@ Enhancements
   reducing the memory needed when receiving datasets (:issue:`517`)
 * Allow parsing of dimse command sets that contain elements with non-conformant
   VMs (:issue:`554`)
+* Added a check when acting as a QR SCP that returns from the event handler
+  if the association is aborted or released (:issue:`592`)
 
 Changes
 .......
 
-* Removed support for Python 2.7 and 3.5
+* Removed support for Python 2.7 and 3.5, added it for Python 3.9
 * Minimum *pydicom* version is 2.0
+* The *Failed SOP Instance UID List* sent with the final C-GET/C-MOVE SCP
+  failure or warning responses no longer includes the SOP Instances for
+  sub-operations that return a warning status

--- a/pynetdicom/service_class.py
+++ b/pynetdicom/service_class.py
@@ -1865,7 +1865,7 @@ class QueryRetrieveServiceClass(ServiceClass):
                 # Update the C-STORE sub-operation result tracker
                 if store_status[0] == STATUS_FAILURE:
                     store_results[1] += 1
-                    # PS3.4, C.4.3.1.3.2
+                    # Part 4, C.4.3.1.3.2
                     _add_failed_instance(dataset)
                 elif store_status[0] == STATUS_WARNING:
                     store_results[2] += 1

--- a/pynetdicom/service_class.py
+++ b/pynetdicom/service_class.py
@@ -1342,6 +1342,10 @@ class ServiceClass(object):
                     self.assoc.acse.is_aborted()
                     or self.assoc.acse.is_release_requested()
                 ):
+                    LOGGER.debug(
+                        "A-ABORT or A-RELEASE-RQ received during "
+                        "Q/R sub-operations"
+                    )
                     return
 
                 yield (result, None)

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -55,7 +55,7 @@ from pynetdicom.sop_class import (
 )
 
 
-#debug_logger()
+debug_logger()
 
 
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')
@@ -2533,7 +2533,7 @@ class TestAssociationSendCGet(object):
         assert status.Status == 0xff00
         assert ds is None
         (status, ds) = next(result)
-        assert status.Status == 0xb000
+        assert status.Status == 0xA702
         assert ds.FailedSOPInstanceUIDList == ['1.1.1', '1.1.1']
         assoc.release()
         assert assoc.is_released
@@ -3443,7 +3443,7 @@ class TestAssociationSendCMove(object):
         (status, ds) = next(result)
         assert status.Status == 0xFF00
         (status, ds) = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         with pytest.raises(StopIteration):
             next(result)
 
@@ -3470,15 +3470,20 @@ class TestAssociationSendCMove(object):
         ae.network_timeout = 5
         ae.add_supported_context(PatientRootQueryRetrieveInformationModelMove)
         move_scp = ae.start_server(
-            ('', 11112), block=False, evt_handlers=[(evt.EVT_C_MOVE, handle_move)]
+            ('', 11112),
+            block=False,
+            evt_handlers=[(evt.EVT_C_MOVE, handle_move)]
         )
 
         ae.add_supported_context(CTImageStorage)
         store_scp = ae.start_server(
-            ('', 11113), block=False, evt_handlers=[(evt.EVT_C_STORE, handle_store)]
+            ('', 11113),
+            block=False,
+            evt_handlers=[(evt.EVT_C_STORE, handle_store)]
         )
 
         ae.add_requested_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_requested_context(CTImageStorage)
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
 
@@ -3568,6 +3573,7 @@ class TestAssociationSendCMove(object):
         )
 
         ae.add_requested_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_requested_context(CTImageStorage)
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
 

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -55,7 +55,7 @@ from pynetdicom.sop_class import (
 )
 
 
-debug_logger()
+#debug_logger()
 
 
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')

--- a/pynetdicom/tests/test_service_qr.py
+++ b/pynetdicom/tests/test_service_qr.py
@@ -57,7 +57,7 @@ def test_unknown_sop_class():
         service.SCP(None, context)
 
 
-class TestQRFindServiceClass(object):
+class TestQRFindServiceClass:
     """Test the QueryRetrieveFindServiceClass"""
     def setup(self):
         """Run prior to each test"""
@@ -1081,7 +1081,7 @@ class TestQRFindServiceClass(object):
         scp.shutdown()
 
 
-class TestQRGetServiceClass(object):
+class TestQRGetServiceClass:
     def setup(self):
         """Run prior to each test"""
         self.query = Dataset()
@@ -1604,14 +1604,18 @@ class TestQRGetServiceClass(object):
 
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
-        assoc = ae.associate('localhost', 11112, ext_neg=[role], evt_handlers=handlers)
+        assoc = ae.associate(
+            'localhost', 11112, ext_neg=[role], evt_handlers=handlers
+        )
         assert assoc.is_established
-        result = assoc.send_c_get(self.query, PatientRootQueryRetrieveInformationModelGet)
+        result = assoc.send_c_get(
+            self.query, PatientRootQueryRetrieveInformationModelGet
+        )
         status, identifier = next(result)
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
@@ -1691,14 +1695,18 @@ class TestQRGetServiceClass(object):
 
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
-        assoc = ae.associate('localhost', 11112, ext_neg=[role], evt_handlers=handlers)
+        assoc = ae.associate(
+            'localhost', 11112, ext_neg=[role], evt_handlers=handlers
+        )
         assert assoc.is_established
-        result = assoc.send_c_get(self.query, PatientRootQueryRetrieveInformationModelGet)
+        result = assoc.send_c_get(
+            self.query, PatientRootQueryRetrieveInformationModelGet
+        )
         status, identifier = next(result)
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
@@ -1782,7 +1790,7 @@ class TestQRGetServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 2
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -1817,9 +1825,13 @@ class TestQRGetServiceClass(object):
 
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
-        assoc = ae.associate('localhost', 11112, ext_neg=[role], evt_handlers=handlers)
+        assoc = ae.associate(
+            'localhost', 11112, ext_neg=[role], evt_handlers=handlers
+        )
         assert assoc.is_established
-        result = assoc.send_c_get(self.query, PatientRootQueryRetrieveInformationModelGet)
+        result = assoc.send_c_get(
+            self.query, PatientRootQueryRetrieveInformationModelGet
+        )
         status, identifier = next(result)
         assert status.Status == 0xFF00
         assert identifier is None
@@ -1831,7 +1843,7 @@ class TestQRGetServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 2
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == ['1.1.1', '1.1.1']
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -1915,7 +1927,7 @@ class TestQRGetServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 1
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -1952,7 +1964,7 @@ class TestQRGetServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 1
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -2056,9 +2068,7 @@ class TestQRGetServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 3
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == ['1.1.1',
-                                                       '1.1.1',
-                                                       '1.1.1']
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -2104,7 +2114,7 @@ class TestQRGetServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 3
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -2141,9 +2151,13 @@ class TestQRGetServiceClass(object):
 
         ae.acse_timeout = 5
         ae.dimse_timeout = 5
-        assoc = ae.associate('localhost', 11112, ext_neg=[role], evt_handlers=handlers)
+        assoc = ae.associate(
+            'localhost', 11112, ext_neg=[role], evt_handlers=handlers
+        )
         assert assoc.is_established
-        result = assoc.send_c_get(self.query, PatientRootQueryRetrieveInformationModelGet)
+        result = assoc.send_c_get(
+            self.query, PatientRootQueryRetrieveInformationModelGet
+        )
         status, identifier = next(result)
         assert status.Status == 0xFF00
         assert identifier is None
@@ -2319,7 +2333,7 @@ class TestQRGetServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 1
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -2732,7 +2746,7 @@ class TestQRGetServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert identifier.FailedSOPInstanceUIDList == '1.1.1'
         pytest.raises(StopIteration, next, result)
 
@@ -3244,8 +3258,59 @@ class TestQRGetServiceClass(object):
         assert assoc.is_released
         scp.shutdown()
 
+    def test_scp_store_warning_failure(self):
+        """Test when handler returns warning status if not all failed"""
+        rsp = [0xC000, 0xB000]
 
-class TestQRMoveServiceClass(object):
+        def handle(event):
+            yield 2
+            yield 0xFF00, self.ds
+            yield 0xFF00, self.ds
+
+        def handle_store(event):
+            return rsp.pop()
+
+        handlers = [(evt.EVT_C_GET, handle)]
+
+        self.ae = ae = AE()
+        ae.add_supported_context(PatientRootQueryRetrieveInformationModelGet)
+        ae.add_supported_context(CTImageStorage, scu_role=False, scp_role=True)
+        ae.add_requested_context(PatientRootQueryRetrieveInformationModelGet)
+        ae.add_requested_context(CTImageStorage)
+        scp = ae.start_server(('', 11112), block=False, evt_handlers=handlers)
+
+        role = build_role(CTImageStorage, scp_role=True)
+        handlers = [(evt.EVT_C_STORE, handle_store)]
+
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        assoc = ae.associate(
+            'localhost', 11112, ext_neg=[role], evt_handlers=handlers
+        )
+        assert assoc.is_established
+        result = assoc.send_c_get(
+            self.query, PatientRootQueryRetrieveInformationModelGet
+        )
+        status, identifier = next(result)
+        assert status.Status == 0xFF00
+        assert identifier is None
+        status, identifier = next(result)
+        assert status.Status == 0xFF00
+        assert identifier is None
+        status, identifier = next(result)
+        assert status.Status == 0xB000
+        assert status.NumberOfFailedSuboperations == 1
+        assert status.NumberOfWarningSuboperations == 1
+        assert status.NumberOfCompletedSuboperations == 0
+        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        pytest.raises(StopIteration, next, result)
+
+        assoc.release()
+        assert assoc.is_released
+        scp.shutdown()
+
+
+class TestQRMoveServiceClass:
     def setup(self):
         """Run prior to each test"""
         self.query = Dataset()
@@ -3900,7 +3965,7 @@ class TestQRMoveServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
@@ -4024,7 +4089,7 @@ class TestQRMoveServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 2
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -4108,7 +4173,7 @@ class TestQRMoveServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 2
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == ['1.1.1', '1.1.1']
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -4186,7 +4251,7 @@ class TestQRMoveServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 1
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -4221,7 +4286,7 @@ class TestQRMoveServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 1
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -4319,9 +4384,7 @@ class TestQRMoveServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 3
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == ['1.1.1',
-                                                       '1.1.1',
-                                                       '1.1.1']
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -4364,7 +4427,7 @@ class TestQRMoveServiceClass(object):
         assert status.Status == 0xFF00
         assert identifier is None
         status, identifier = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         assert status.NumberOfFailedSuboperations == 3
         assert status.NumberOfWarningSuboperations == 0
         assert status.NumberOfCompletedSuboperations == 0
@@ -4528,7 +4591,7 @@ class TestQRMoveServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 1
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -5045,7 +5108,7 @@ class TestQRMoveServiceClass(object):
         assert status.NumberOfFailedSuboperations == 0
         assert status.NumberOfWarningSuboperations == 1
         assert status.NumberOfCompletedSuboperations == 0
-        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        assert identifier.FailedSOPInstanceUIDList == ''
         pytest.raises(StopIteration, next, result)
 
         assoc.release()
@@ -5544,8 +5607,59 @@ class TestQRMoveServiceClass(object):
         assert assoc.is_released
         scp.shutdown()
 
+    def test_scp_store_warning_failure(self):
+        """Test when handler returns warning status if not all failed"""
+        rsp = [0xC000, 0xB000, 0xB000]
 
-class TestQRCompositeInstanceWithoutBulk(object):
+        def handle(event):
+            yield self.destination
+            yield 3
+            yield 0xFF00, self.ds
+            yield 0xFF00, self.ds
+            yield 0xFF00, self.ds
+            yield 0xB000, None
+
+        def handle_store(event):
+            return rsp.pop()
+
+        handlers = [(evt.EVT_C_MOVE, handle), (evt.EVT_C_STORE, handle_store)]
+
+        self.ae = ae = AE()
+        ae.add_supported_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_supported_context(CTImageStorage, scu_role=False, scp_role=True)
+        ae.add_requested_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_requested_context(CTImageStorage)
+        scp = ae.start_server(('', 11112), block=False, evt_handlers=handlers)
+
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        assoc = ae.associate('localhost', 11112)
+        assert assoc.is_established
+        result = assoc.send_c_move(
+            self.query, b'TESTMOVE', PatientRootQueryRetrieveInformationModelMove
+        )
+        status, identifier = next(result)
+        assert status.Status == 0xFF00
+        assert identifier is None
+        status, identifier = next(result)
+        assert status.Status == 0xFF00
+        assert identifier is None
+        status, identifier = next(result)
+        assert status.Status == 0xFF00
+        assert identifier is None
+        status, identifier = next(result)
+        assert status.Status == 0xB000
+        assert status.NumberOfFailedSuboperations == 1
+        assert status.NumberOfWarningSuboperations == 2
+        assert status.NumberOfCompletedSuboperations == 0
+        assert identifier.FailedSOPInstanceUIDList == '1.1.1'
+        pytest.raises(StopIteration, next, result)
+
+        assoc.release()
+        scp.shutdown()
+
+
+class TestQRCompositeInstanceWithoutBulk:
     """Tests for QR + Composite Instance Without Bulk Data"""
     def setup(self):
         """Run prior to each test"""
@@ -5754,7 +5868,7 @@ class TestQRCompositeInstanceWithoutBulk(object):
         scp.shutdown()
 
 
-class TestBasicWorklistServiceClass(object):
+class TestBasicWorklistServiceClass:
     """Tests for BasicWorklistManagementServiceClass."""
     def setup(self):
         """Run prior to each test"""

--- a/pynetdicom/tests/test_service_qr.py
+++ b/pynetdicom/tests/test_service_qr.py
@@ -40,7 +40,7 @@ from pynetdicom.sop_class import (
 )
 
 
-debug_logger()
+#debug_logger()
 
 
 TEST_DS_DIR = os.path.join(os.path.dirname(__file__), 'dicom_files')


### PR DESCRIPTION
#### Reference issue
* Closes #592, closes #577
* Return failure status if all Move or Get suboperations failed
* Don't include the SOP instance UIDs for suboperations that return warning status
* Add abort/release check during Find/Move/Get SCP handler operation

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and coverage at 100% after adding fix/feature
