### PR TITLE
[MRG] Backport for QR fixes

### DIFF
--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -7,6 +7,7 @@ Release Notes
 .. toctree::
    :maxdepth: 1
 
+   v1.5.7
    v1.5.6
    v1.5.5
    v1.5.4

--- a/docs/changelog/v1.5.7.rst
+++ b/docs/changelog/v1.5.7.rst
@@ -1,0 +1,19 @@
+.. _v1.5.7:
+
+1.5.7
+=====
+
+Fixes
+.....
+
+* Fixed not sending a failure response if all C-GET or C-MOVE sub-operations
+  failed when acting as an Query/Retrieve SCP (:issue:`577`)
+* Fixed not using the correct *Move Originator Message ID* when sending
+  C-STORE-RQs when acting as a Move SCP (:issue:`541`)
+
+Changes
+.......
+
+* The Failed SOP Instance UID List sent with the final C-GET/C-MOVE SCP
+  failure or warning responses no longer includes the SOP Instances for
+  sub-operations that return a warning status

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,6 +119,7 @@ Applications
 Release Notes
 =============
 
+* :doc:`v1.5.7 </changelog/v1.5.7>`
 * :doc:`v1.5.6 </changelog/v1.5.6>`
 * :doc:`v1.5.5 </changelog/v1.5.5>`
 * :doc:`v1.5.4 </changelog/v1.5.4>`

--- a/pynetdicom/service_class.py
+++ b/pynetdicom/service_class.py
@@ -1840,7 +1840,6 @@ class QueryRetrieveServiceClass(ServiceClass):
                     _add_failed_instance(dataset)
                 elif store_status[0] == STATUS_WARNING:
                     store_results[2] += 1
-                    _add_failed_instance(dataset)
                 elif store_status[0] == STATUS_SUCCESS:
                     store_results[3] += 1
 
@@ -1864,9 +1863,15 @@ class QueryRetrieveServiceClass(ServiceClass):
             rsp.Status = 0x0000
             rsp.Identifier = None
         else:
-            # Warning response - one or more failures or warnings
-            LOGGER.info('Get SCP Response {}: 0xB000 (Warning)'.format(ii + 2))
-            rsp.Status = 0xB000
+            if no_suboperations == store_results[1]:
+                # Failure response - all sub-operations failed
+                LOGGER.info(f'Get SCP Response {ii + 2}: 0xA702 (Failure)')
+                rsp.Status = 0xA702  # Unable to perform sub-ops
+            else:
+                # Warning response - one or more failures or warnings
+                LOGGER.info(f'Get SCP Response {ii + 2}: 0xB000 (Warning)')
+                rsp.Status = 0xB000
+
             # If Warning response, need to return an Identifier with
             #   (0008,0058) Failed SOP Instance UID List element
             ds = Dataset()
@@ -2213,7 +2218,7 @@ class QueryRetrieveServiceClass(ServiceClass):
                         dataset,
                         msg_id=msg_id,
                         originator_aet=self.ae.ae_title,
-                        originator_id=1
+                        originator_id=req.MessageID
                     )
 
                     store_status_int = store_status.Status
@@ -2246,7 +2251,6 @@ class QueryRetrieveServiceClass(ServiceClass):
                     _add_failed_instance(dataset)
                 elif store_status[0] == STATUS_WARNING:
                     store_results[2] += 1
-                    _add_failed_instance(dataset)
                 elif store_status[0] == STATUS_SUCCESS:
                     store_results[3] += 1
 
@@ -2275,11 +2279,15 @@ class QueryRetrieveServiceClass(ServiceClass):
             rsp.Status = 0x0000
             rsp.Identifier = None
         else:
-            # Warning response - one or more failures or warnings
-            LOGGER.info(
-                'Move SCP Response {}: 0xB000 (Warning)'.format(ii + 2)
-            )
-            rsp.Status = 0xB000
+            if no_suboperations == store_results[1]:
+                # Failure response - all sub-operations failed
+                LOGGER.info(f'Move SCP Response {ii + 2}: 0xA702 (Failure)')
+                rsp.Status = 0xA702  # Unable to perform sub-ops
+            else:
+                # Warning response - one or more failures or warnings
+                LOGGER.info(f'Move SCP Response {ii + 2}: 0xB000 (Warning)')
+                rsp.Status = 0xB000
+
             # If Warning response, need to return an Identifier with
             #   (0008, 0058) Failed SOP Instance UID List element
             ds = Dataset()

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -2382,7 +2382,7 @@ class TestAssociationSendCGet(object):
         assert status.Status == 0xff00
         assert ds is None
         (status, ds) = next(result)
-        assert status.Status == 0xb000
+        assert status.Status == 0xA702
         assert ds.FailedSOPInstanceUIDList == ['1.1.1', '1.1.1']
         assoc.release()
         assert assoc.is_released
@@ -3257,7 +3257,7 @@ class TestAssociationSendCMove(object):
         (status, ds) = next(result)
         assert status.Status == 0xFF00
         (status, ds) = next(result)
-        assert status.Status == 0xB000
+        assert status.Status == 0xA702
         with pytest.raises(StopIteration):
             next(result)
 
@@ -3293,6 +3293,7 @@ class TestAssociationSendCMove(object):
         )
 
         ae.add_requested_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_requested_context(CTImageStorage)
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
 
@@ -3382,6 +3383,7 @@ class TestAssociationSendCMove(object):
         )
 
         ae.add_requested_context(PatientRootQueryRetrieveInformationModelMove)
+        ae.add_requested_context(CTImageStorage)
         assoc = ae.associate('localhost', 11112)
         assert assoc.is_established
 


### PR DESCRIPTION
#### Reference issue
* Send failure response if all QR subops fail
* Send correct Move Originator Message ID
* Don't include warning SOP Instances in Failed SOP instance UID List

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
