### PR TITLE
[MRG] Add better handling of invalid A-ASSOCIATE (RJ) parameters during ACSE negotiation

### DIFF
--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -48,6 +48,8 @@ Enhancements
   option (:issue:`620`)
 * Updated to meet the 2021b version of the DICOM Standard
 * Added type hints
+* Handle non-conformant A-ASSOCIATE (RJ) 'Result', 'Source' and 'Diagnostic'
+  values during ACSE negotiation (:issue:`633`)
 
 Changes
 .......

--- a/pynetdicom/pdu.py
+++ b/pynetdicom/pdu.py
@@ -1225,16 +1225,14 @@ class A_ASSOCIATE_RJ(PDU):
         }
 
         if self.source not in _reasons:
-            LOGGER.error('Invalid value in Source field in '
-                         'A-ASSOCIATE-RJ PDU')
-            raise ValueError('Invalid value in Source field in '
-                             'A-ASSOCIATE-RJ PDU')
+            msg = 'Invalid value in Source field in A-ASSOCIATE-RJ PDU'
+            LOGGER.error(msg)
+            raise ValueError(msg)
 
         if self.reason_diagnostic not in _reasons[self.source]:
-            LOGGER.error('Invalid value in Reason field in '
-                         'A-ASSOCIATE-RJ PDU')
-            raise ValueError('Invalid value in Reason field in '
-                             'A-ASSOCIATE-RJ PDU')
+            msg = 'Invalid value in Reason field in A-ASSOCIATE-RJ PDU'
+            LOGGER.error(msg)
+            raise ValueError(msg)
 
         return _reasons[self.source][self.reason_diagnostic]
 
@@ -1247,10 +1245,9 @@ class A_ASSOCIATE_RJ(PDU):
         }
 
         if self.result not in _results:
-            LOGGER.error('Invalid value in Result field in '
-                         'A-ASSOCIATE-RJ PDU')
-            raise ValueError('Invalid value in Result field in '
-                             'A-ASSOCIATE-RJ PDU')
+            msg = 'Invalid value in Result field in A-ASSOCIATE-RJ PDU'
+            LOGGER.error(msg)
+            raise ValueError(msg)
 
         return _results[self.result]
 
@@ -1264,10 +1261,9 @@ class A_ASSOCIATE_RJ(PDU):
         }
 
         if self.source not in _sources:
-            LOGGER.error('Invalid value in Source field in '
-                         'A-ASSOCIATE-RJ PDU')
-            raise ValueError('Invalid value in Source field in '
-                             'A-ASSOCIATE-RJ PDU')
+            msg = 'Invalid value in Source field in A-ASSOCIATE-RJ PDU'
+            LOGGER.error(msg)
+            raise ValueError(msg)
 
         return _sources[self.source]
 

--- a/pynetdicom/pdu_primitives.py
+++ b/pynetdicom/pdu_primitives.py
@@ -345,7 +345,16 @@ class A_ASSOCIATE:
     @property
     def result_str(self) -> str:
         """Return the result as str."""
-        results = {1: "Rejected Permanent", 2: "Rejected Transient"}
+        results = {
+            0: "Accepted", 1: "Rejected Permanent", 2: "Rejected Transient"
+        }
+
+        if self.result not in results:
+            LOGGER.error(
+                f"Invalid A-ASSOCIATE 'Result' {self.result}"
+            )
+            return "(no value available)"
+
         return results[cast(int, self.result)]
 
     @property
@@ -387,6 +396,12 @@ class A_ASSOCIATE:
             2: 'Service Provider (ACSE)',
             3: 'Service Provider (Presentation)'
         }
+        if self.result_source not in sources:
+            LOGGER.error(
+                f"Invalid A-ASSOCIATE 'Result Source' {self.result_source}"
+            )
+            return "(no value available)"
+
         return sources[cast(int, self.result_source)]
 
     @property
@@ -463,7 +478,14 @@ class A_ASSOCIATE:
         }
         result = cast(int, self.result_source)
         diagnostic = cast(int, self.diagnostic)
-        return reasons[result][diagnostic]
+        try:
+            return reasons[result][diagnostic]
+        except KeyError:
+            LOGGER.error(
+                f"Invalid A-ASSOCIATE 'Result Source' {result} and/or "
+                f"'Diagnostic' {diagnostic} values"
+            )
+            return "(no value available)"
 
     @property
     def calling_presentation_address(self) -> Optional[Tuple[str, int]]:

--- a/pynetdicom/pdu_primitives.py
+++ b/pynetdicom/pdu_primitives.py
@@ -355,7 +355,7 @@ class A_ASSOCIATE:
             )
             return "(no value available)"
 
-        return results[cast(int, self.result)]
+        return results[self.result]
 
     @property
     def result_source(self) -> Optional[int]:
@@ -402,7 +402,7 @@ class A_ASSOCIATE:
             )
             return "(no value available)"
 
-        return sources[cast(int, self.result_source)]
+        return sources[self.result_source]
 
     @property
     def diagnostic(self) -> Optional[int]:

--- a/pynetdicom/tests/test_primitives.py
+++ b/pynetdicom/tests/test_primitives.py
@@ -1012,6 +1012,35 @@ class TestPrimitive_A_ASSOCIATE:
             b"\x43\x4f\x4d\x5f\x30\x39\x30"
         )
 
+    def test_invalid_result_str(self, caplog):
+        """Test an invalid result value gets logged and doesn't raise."""
+        pdu = A_ASSOCIATE()
+        pdu.result = None
+        with caplog.at_level(logging.ERROR, logger='pynetdicom'):
+            assert pdu.result_str == '(no value available)'
+            assert "Invalid A-ASSOCIATE 'Result' None" in caplog.text
+
+    def test_invalid_source_str(self, caplog):
+        """Test an invalid source value gets logged and doesn't raise."""
+        pdu = A_ASSOCIATE()
+        pdu.result_source = None
+        with caplog.at_level(logging.ERROR, logger='pynetdicom'):
+            assert pdu.source_str == '(no value available)'
+            assert "Invalid A-ASSOCIATE 'Result Source' None" in caplog.text
+
+    def test_invalid_reason_str(self, caplog):
+        """Test an invalid diagnostic value gets logged and doesn't raise."""
+        pdu = A_ASSOCIATE()
+        pdu.result = 1
+        pdu.result_source = 2
+        pdu.diagnostic = 7
+        with caplog.at_level(logging.ERROR, logger='pynetdicom'):
+            assert pdu.reason_str == '(no value available)'
+            assert (
+                "Invalid A-ASSOCIATE 'Result Source' 2 and/or "
+                "'Diagnostic' 7 values"
+            ) in caplog.text
+
 
 class TestPrimitive_A_RELEASE:
     def test_assignment(self):


### PR DESCRIPTION
#### Reference issue
Related to #633, handle invalid result, source and diagnostic parameters in the A_ASSOCIATE string methods.

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
