### PR TITLE
Add DCMTK only benchmark

### DIFF
--- a/pynetdicom/tests/benchmark_script.py
+++ b/pynetdicom/tests/benchmark_script.py
@@ -288,8 +288,6 @@ def receive_store_dcmtk(nr_assoc, ds_per_assoc, use_yappi=False):
     time.sleep(0.5)
 
     start_time = time.time()
-    run_times = []
-
     is_successful = True
 
     for ii in range(nr_assoc):

--- a/pynetdicom/tests/benchmark_script.py
+++ b/pynetdicom/tests/benchmark_script.py
@@ -268,6 +268,51 @@ def receive_store_internal(nr_assoc, ds_per_assoc, write_ds=0, use_yappi=False):
     server.shutdown()
 
 
+def receive_store_dcmtk(nr_assoc, ds_per_assoc, use_yappi=False):
+    """Run a Storage SCP and transfer datasets with sequential storescu's.
+
+    Parameters
+    ----------
+    nr_assoc : int
+        The total number of (sequential) associations that will be made.
+    ds_per_assoc : int
+        The number of C-STORE requests sent per successful association.
+    use_yappi : bool, optional
+        True to use the yappi profiler, False otherwise (default).
+    """
+    if use_yappi:
+        init_yappi()
+
+    # Start SCP
+    server = start_storescp()
+    time.sleep(0.5)
+
+    start_time = time.time()
+    run_times = []
+
+    is_successful = True
+
+    for ii in range(nr_assoc):
+        p = start_storescu(ds_per_assoc)
+        # Block until transfer is complete
+        p.wait()
+        if p.returncode != 0:
+            is_successful = False
+            break
+
+    if is_successful:
+        print(
+            "C-STORE SCP transferred {} total datasets over {} "
+            "association(s) in {:.2f} s"
+            .format(nr_assoc * ds_per_assoc, nr_assoc, time.time() - start_time)
+        )
+    else:
+        print("C-STORE SCP benchmark failed")
+
+    server.terminate()
+
+
+
 def receive_store_simultaneous(nr_assoc, ds_per_assoc, use_yappi=False):
     """Run a Storage SCP and transfer datasets with simultaneous storescu's.
 
@@ -412,6 +457,7 @@ if __name__ == "__main__":
     print("  7. Storage SCP, 1 dataset per association over 1000 associations")
     print("  8. Storage SCP, 1000 datasets per association over 10 simultaneous associations")
     print("  9. Storage SCU/SCP, 1000 datasets over 1 association")
+    print("  10. Storage DCMTK SCU/SCP, 1000 datasets over 1 association")
     bench_index = input()
 
     if bench_index == "1":
@@ -432,3 +478,6 @@ if __name__ == "__main__":
         receive_store_simultaneous(10, 1000, use_yappi)
     elif bench_index == "9":
         receive_store_internal(1, 1000, 0, use_yappi)
+    elif bench_index == "10":
+        receive_store_dcmtk(1, 1000, use_yappi)
+


### PR DESCRIPTION
Added benchmark for dcmtk scu/scp for comparison. Current benchmarks have pynetdicom only version but no dcmtk only version for a fair comparison.

Here are the benchmarks on my MBA M1:

```
$ python pynetdicom/tests/benchmark_script.py 
Use yappi (y/n:)
n
Which benchmark do you wish to run?
  1. Storage SCU, 1000 datasets over 1 association
  2. Storage SCU, 1 dataset per association over 1000 associations
  3. Storage SCP, 1000 datasets over 1 association
  4. Storage SCP, 1000 datasets over 1 association (write)
  5. Storage SCP, 1000 datasets over 1 association (write fast)
  6. Storage SCP, 1000 datasets over 1 association (write fastest)
  7. Storage SCP, 1 dataset per association over 1000 associations
  8. Storage SCP, 1000 datasets per association over 10 simultaneous associations
  9. Storage SCU/SCP, 1000 datasets over 1 association
  10. Storage DCMTK SCU/SCP, 1000 datasets over 1 association
```

| benchmark id | time |
|--|-----|
| 1 | 9.27 s|
| 2 | 31.89 s|
| 3 | 8.69 s |
| 4 | 12.63 s |
| 5 | 9.32 s | 
| 6 | 6.37 s | 
| 7 |  57.08 s|
| 8 |  11.97 s |
|9 | 12.59 s | 
| 10 | 2.00 s| 

It's sobering to see performance of 9 vs 10. DCMTK is roughly 6 times faster than pynetdicom. Do you think if there is something that can be done to speed pynetdicom up?