### PR TITLE
[MRG] Work around LGTM errors: Clear-text logging of sensitive information

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+---
+queries:
+  # https://lgtm.com/rules/1510014536001/
+  - exclude: py/clear-text-logging-sensitive-data


### PR DESCRIPTION
Disable false positives that cannot be fixed by LGTM, because their heuristic detects strings such "`id`" that are actually very common in DICOM, for example in "`UID`".

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [X] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Type annotations updated and passing with mypy
- [ ] Apps updated and tested (if relevant)
