### PR TITLE
[MRG] Refactor DUL to remove primitive and pdu attributes

### DIFF
--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -99,3 +99,5 @@ Changes
 * The default bind address used when making association requests changed to
   ``("127.0.0.1", 0)`` (:issue:`680`)
 * ``DULServiceProvider.primitive`` and ``DULServiceProvider.pdu`` have been removed
+* :meth:`~pynetdicom.transport.AssociationSocket.connect` now takes a
+  :class:`~pynetdicom.transport.T_CONNECT` primitive

--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -35,6 +35,9 @@ Fixes
 * Fixed `qrscp --clean` (:issue:`681`, :issue:`682`)
 * Fixed a memory leak when running :class:`~pynetdicom.transport.AssociationServer`
   due to old Association threads not being garbage collected (:issue:`669`)
+* Fixed an exception in the state machine during association negotiation as the acceptor
+  when an A-ABORT-RQ PDU is received before the initial A-ASSOCIATE-RQ has been
+  processed (:issue:`721`)
 
 
 Enhancements
@@ -95,3 +98,4 @@ Changes
   ASCII :class:`str` rather than :class:`bytes`
 * The default bind address used when making association requests changed to
   ``("127.0.0.1", 0)`` (:issue:`680`)
+* ``DULServiceProvider.primitive`` and ``DULServiceProvider.pdu`` have been removed

--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -99,5 +99,5 @@ Changes
 * The default bind address used when making association requests changed to
   ``("127.0.0.1", 0)`` (:issue:`680`)
 * ``DULServiceProvider.primitive`` and ``DULServiceProvider.pdu`` have been removed
-* :meth:`~pynetdicom.transport.AssociationSocket.connect` now takes a
-  :class:`~pynetdicom.transport.T_CONNECT` primitive
+* :meth:`AssociationSocket.connect<pynetdicom.transport.AssociationSocket.connect>`
+  now takes a :class:`~pynetdicom.transport.T_CONNECT` primitive

--- a/docs/reference/transport.rst
+++ b/docs/reference/transport.rst
@@ -19,3 +19,4 @@ communication with peer AEs.
    AssociationServer
    RequestHandler
    ThreadedAssociationServer
+   T_CONNECT

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -253,11 +253,6 @@ class ACSE:
         """Return the :class:`~pynetdicom.dul.DULServiceProvider`."""
         return self.assoc.dul
 
-    @property
-    def socket(self) -> Optional["AssociationSocket"]:
-        """Return the :class:`~pynetdicom.transport.AssociationSocket`."""
-        return self.assoc.dul.socket
-
     def is_aborted(self, abort_type: str = "both") -> bool:
         """Return ``True`` if an A-ABORT and/or A-P-ABORT request has been
         received.
@@ -870,3 +865,8 @@ class ACSE:
 
         # Send the A-ASSOCIATE request primitive to the peer
         self.dul.send_pdu(primitive)
+
+    @property
+    def socket(self) -> Optional["AssociationSocket"]:
+        """Return the :class:`~pynetdicom.transport.AssociationSocket`."""
+        return self.assoc.dul.socket

--- a/pynetdicom/dimse.py
+++ b/pynetdicom/dimse.py
@@ -298,6 +298,8 @@ class DIMSEServiceProvider:
                 LOGGER.error("Received an invalid DIMSE message")
                 LOGGER.exception(exc)
                 self.dul.event_queue.put("Evt19")
+                # Shouldn't need to reset `self.message` as Evt19 will end
+                #   the association
                 return
 
             # Keep C-CANCEL requests separate from other messages

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -117,8 +117,8 @@ class DULServiceProvider(Thread):
         try:
             # Check the queue and see if there are any primitives
             # If so then put the corresponding event on the event queue
-            #self.primitive = self.to_provider_queue.get(False)
-            #self.event_queue.put(self._primitive_to_event(self.primitive))
+            # self.primitive = self.to_provider_queue.get(False)
+            # self.event_queue.put(self._primitive_to_event(self.primitive))
             primitive = self.to_provider_queue.queue[0]
             self.event_queue.put(self._primitive_to_event(primitive))
             return True

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -38,8 +38,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.association import Association
     from pynetdicom.transport import AssociationSocket
 
-
-_QueueType = queue.Queue[Union[_PDUPrimitiveType, T_CONNECT]]
+    _QueueType = queue.Queue[Union[_PDUPrimitiveType, T_CONNECT]]
 
 
 LOGGER = logging.getLogger("pynetdicom.dul")
@@ -85,7 +84,7 @@ class DULServiceProvider(Thread):
         #   user and the DUL service provider.
         # An event occurs when the DUL service user adds to
         #   the to_provider_queue
-        self.to_provider_queue: _QueueType = queue.Queue()
+        self.to_provider_queue: "_QueueType" = queue.Queue()
         # A primitive is sent to the service user when the DUL service provider
         # adds to the to_user_queue.
         self.to_user_queue: "queue.Queue[_PDUPrimitiveType]" = queue.Queue()

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -89,7 +89,10 @@ class DULServiceProvider(Thread):
         self.to_user_queue: "queue.Queue[_PDUPrimitiveType]" = queue.Queue()
 
         # A queue storing PDUs received from the peer
-        self._recv_pdu = queue.Queue()
+        self._recv_pdu: "queue.Queue[_PDUType]" = queue.Queue()
+
+        # FIXME: more elegant method needed
+        self._tmp: Optional["A_ASSOCIATE"] = None
 
         # Set the (network) idle and ARTIM timers
         # Timeouts gets set after DUL init so these are temporary
@@ -210,7 +213,7 @@ class DULServiceProvider(Thread):
             return None
 
     @staticmethod
-    def _primitive_to_event(primitive: _PDUPrimitiveType) -> Optional[str]:
+    def _primitive_to_event(primitive: _PDUPrimitiveType) -> str:
         """Returns the state machine event associated with sending a primitive.
 
         Parameters

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -38,7 +38,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.association import Association
     from pynetdicom.transport import AssociationSocket
 
-    _QueueType = queue.Queue[Union[_PDUPrimitiveType, T_CONNECT]]
+
+_QueueType = queue.Queue[Union[_PDUPrimitiveType, T_CONNECT]]
 
 
 LOGGER = logging.getLogger("pynetdicom.dul")

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -55,8 +55,7 @@ class DULServiceProvider(Thread):
     to_provider_queue : queue.Queue
         Queue of primitives received from the peer to be processed by the service user.
     to_user_queue : queue.Queue
-        Queue of primitives received from the service user to be processed by the
-        DUL service.
+        Queue of processed PDUs for the DUL service user.
     event_queue : queue.Queue
         List of queued events to be processed by the state machine.
     state_machine : fsm.StateMachine
@@ -335,7 +334,8 @@ class DULServiceProvider(Thread):
         Returns
         -------
         Optional[Union[A_ASSOCIATE, A_RELEASE, A_ABORT, A_P_ABORT]]
-            The next primitive in the :attr:`~DULServiceProvider.to_user_queue`.
+            The next primitive in the :attr:`~DULServiceProvider.to_user_queue`, or
+            ``None`` if the queue is empty.
         """
         try:
             # If block is True and timeout is None then block until an item

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -99,15 +99,15 @@ class StateMachine:
                     "next_state": next_state,
                 },
             )
-            # print(
-            #     "{}: {} + {} -> {} -> {}".format(
-            #         self.dul.assoc.mode[0].upper(),
-            #         self.current_state,
-            #         event,
-            #         action_name,
-            #         next_state,
-            #     )
-            # )
+            print(
+                "{}: {} + {} -> {} -> {}".format(
+                    self.dul.assoc.mode[0].upper(),
+                    self.current_state,
+                    event,
+                    action_name,
+                    next_state,
+                )
+            )
 
             # Move the state machine to the next state
             self.transition(next_state)
@@ -346,8 +346,6 @@ def AE_6(dul: "DULServiceProvider") -> str:
         )
 
         # Send A-ASSOCIATE-RJ PDU and start ARTIM timer
-        # primitive is A_ASSOCIATE
-
         primitive.result = 0x01
         primitive.result_source = 0x02
         primitive.diagnostic = 0x02
@@ -478,10 +476,9 @@ def DT_2(dul: "DULServiceProvider") -> str:
     """
     # P-DATA-TF PDU received from peer
     pdu = dul._recv_pdu.get(False)
-    primitive = cast("P_DATA", pdu.to_primitive())
 
     # Send P-DATA indication primitive directly to DIMSE for processing
-    dul.assoc.dimse.receive_primitive(primitive)
+    dul.assoc.dimse.receive_primitive(cast("P_DATA", pdu.to_primitive()))
 
     return "Sta6"
 
@@ -535,10 +532,9 @@ def AR_2(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RQ PDU received from peer
     pdu = dul._recv_pdu.get(False)
-    primitive = cast("A_RELEASE", pdu.to_primitive())
 
     # Send A-RELEASE indication primitive
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
 
     return "Sta8"
 
@@ -563,10 +559,9 @@ def AR_3(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RP PDU received from peer
     pdu = dul._recv_pdu.get(False)
-    primitive = cast("A_RELEASE", pdu.to_primitive())
 
     # Issue A-RELEASE confirmation primitive and close transport connection
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
     sock = cast("AssociationSocket", dul.socket)
     sock.close()
 
@@ -663,10 +658,9 @@ def AR_6(dul: "DULServiceProvider") -> str:
     """
     # P-DATA-TF PDU received from peer
     pdu = cast("P_DATA_TF", dul._recv_pdu.get(False))
-    primitive = pdu.to_primitive()
 
     # Issue P-DATA indication
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
 
     return "Sta7"
 
@@ -722,10 +716,9 @@ def AR_8(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RQ PDU received from peer
     pdu = cast("A_RELEASE_RQ", dul._recv_pdu.get(False))
-    primitive = pdu.to_primitive()
 
     # Issue A-RELEASE indication (release collision)
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
     if dul.assoc.is_requestor:
         return "Sta9"
 
@@ -781,10 +774,9 @@ def AR_10(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RP PDU received from peer
     pdu = cast("A_RELEASE_RP", dul._recv_pdu.get(False))
-    primitive = pdu.to_primitive()
 
     # Issue A-RELEASE confirmation primitive
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
 
     return "Sta12"
 
@@ -890,14 +882,13 @@ def AA_3(dul: "DULServiceProvider") -> str:
     """
     # A-ABORT PDU received from peer
     pdu = cast("A_ABORT_RQ", dul._recv_pdu.get(False))
-    primitive = cast("A_ABORT", pdu.to_primitive())
 
     # If (service-user initiated abort):
     #   - Issue A-ABORT indication and close transport connection.
     # Otherwise (service-dul initiated abort):
     #   - Issue A-P-ABORT indication and close transport connection.
     # This action is triggered by the reception of an A-ABORT PDU
-    dul.to_user_queue.put(primitive)
+    dul.to_user_queue.put(pdu.to_primitive())
     sock = cast("AssociationSocket", dul.socket)
     sock.close()
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -99,15 +99,15 @@ class StateMachine:
                     "next_state": next_state,
                 },
             )
-            # print(
-            #     "{}: {} + {} -> {} -> {}".format(
-            #         self.dul.assoc.mode[0].upper(),
-            #         self.current_state,
-            #         event,
-            #         action_name,
-            #         next_state,
-            #     )
-            # )
+            print(
+                "{}: {} + {} -> {} -> {}".format(
+                    self.dul.assoc.mode[0].upper(),
+                    self.current_state,
+                    event,
+                    action_name,
+                    next_state,
+                )
+            )
 
             # Move the state machine to the next state
             self.transition(next_state)

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -99,15 +99,15 @@ class StateMachine:
                     "next_state": next_state,
                 },
             )
-            print(
-                "{}: {} + {} -> {} -> {}".format(
-                    self.dul.assoc.mode[0].upper(),
-                    self.current_state,
-                    event,
-                    action_name,
-                    next_state,
-                )
-            )
+            # print(
+            #     "{}: {} + {} -> {} -> {}".format(
+            #         self.dul.assoc.mode[0].upper(),
+            #         self.current_state,
+            #         event,
+            #         action_name,
+            #         next_state,
+            #     )
+            # )
 
             # Move the state machine to the next state
             self.transition(next_state)

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -20,7 +20,7 @@ from pynetdicom.pdu_primitives import A_P_ABORT, A_ABORT
 if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.dul import DULServiceProvider
     from pynetdicom.transport import AssociationSocket
-    from pynetdicom.pdu_primitives import A_ASSOCIATE, P_DATA, A_RELEASE, A_ABORT
+    from pynetdicom.pdu_primitives import A_ASSOCIATE, P_DATA, A_RELEASE
 
 
 LOGGER = logging.getLogger("pynetdicom.sm")
@@ -206,12 +206,10 @@ def AE_2(dul: "DULServiceProvider") -> str:
     # TRANSPORT CONNECTION confirmation received from transport service
 
     # A-ASSOCIATE (RQ) primitive received from local user
-    # primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
     primitive = cast("A_ASSOCIATE", dul._tmp)
 
     # Send A-ASSOCIATE-RQ PDU to the peer
-    pdu = A_ASSOCIATE_RQ()
-    pdu.from_primitive(primitive)
+    pdu = A_ASSOCIATE_RQ(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -354,8 +352,7 @@ def AE_6(dul: "DULServiceProvider") -> str:
         primitive.result_source = 0x02
         primitive.diagnostic = 0x02
 
-        pdu = A_ASSOCIATE_RJ()
-        pdu.from_primitive(primitive)
+        pdu = A_ASSOCIATE_RJ(primitive)
 
         sock = cast("AssociationSocket", dul.socket)
         sock.send(pdu.encode())
@@ -392,8 +389,7 @@ def AE_7(dul: "DULServiceProvider") -> str:
     primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
 
     # Send A-ASSOCIATE-AC PDU
-    pdu = A_ASSOCIATE_AC()
-    pdu.from_primitive(primitive)
+    pdu = A_ASSOCIATE_AC(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -423,8 +419,7 @@ def AE_8(dul: "DULServiceProvider") -> str:
     primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
 
     # Send A-ASSOCIATE-RJ PDU and start ARTIM timer
-    pdu = A_ASSOCIATE_RJ()
-    pdu.from_primitive(primitive)
+    pdu = A_ASSOCIATE_RJ(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -455,8 +450,7 @@ def DT_1(dul: "DULServiceProvider") -> str:
     primitive = cast("P_DATA", dul.to_provider_queue.get(False))
 
     # Send P-DATA-TF PDU
-    pdu = P_DATA_TF()
-    pdu.from_primitive(primitive)
+    pdu = P_DATA_TF(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -513,8 +507,7 @@ def AR_1(dul: "DULServiceProvider") -> str:
     primitive = cast("A_RELEASE", dul.to_provider_queue.get(False))
 
     # Send A-RELEASE-RQ PDU
-    pdu = A_RELEASE_RQ()
-    pdu.from_primitive(primitive)
+    pdu = A_RELEASE_RQ(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -609,8 +602,7 @@ def AR_4(dul: "DULServiceProvider") -> str:
     primitive = cast("A_RELEASE", dul.to_provider_queue.get(False))
 
     # Issue A-RELEASE-RP PDU and start ARTIM timer
-    pdu = A_RELEASE_RP()
-    pdu.from_primitive(primitive)
+    pdu = A_RELEASE_RP(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -701,8 +693,7 @@ def AR_7(dul: "DULServiceProvider") -> str:
     primitive = cast("P_DATA", dul.to_provider_queue.get(False))
 
     # Issue P-DATA-TF PDU
-    pdu = P_DATA_TF()
-    pdu.from_primitive(primitive)
+    pdu = P_DATA_TF(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -762,8 +753,7 @@ def AR_9(dul: "DULServiceProvider") -> str:
     primitive = cast("A_RELEASE", dul.to_provider_queue.get(False))
 
     # Send A-RELEASE-RP PDU
-    pdu = A_RELEASE_RP()
-    pdu.from_primitive(primitive)
+    pdu = A_RELEASE_RP(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())
@@ -1036,8 +1026,7 @@ def AA_7(dul: "DULServiceProvider") -> str:
     primitive.provider_reason = 0x02
 
     # Send A-ABORT PDU
-    pdu = A_ABORT_RQ()
-    pdu.from_primitive(primitive)
+    pdu = A_ABORT_RQ(primitive)
 
     sock = cast("AssociationSocket", dul.socket)
     sock.send(pdu.encode())

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -100,10 +100,13 @@ class StateMachine:
                 },
             )
             print(
-               "{}: {} + {} -> {} -> {}".format(
-                   self.dul.assoc.mode[0].upper(), self.current_state,
-                   event, action_name, next_state
-               )
+                "{}: {} + {} -> {} -> {}".format(
+                    self.dul.assoc.mode[0].upper(),
+                    self.current_state,
+                    event,
+                    action_name,
+                    next_state,
+                )
             )
 
             # Move the state machine to the next state
@@ -203,7 +206,7 @@ def AE_2(dul: "DULServiceProvider") -> str:
     # TRANSPORT CONNECTION confirmation received from transport service
 
     # A-ASSOCIATE (RQ) primitive received from local user
-    #primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
+    # primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
     primitive = dul._tmp
 
     # Send A-ASSOCIATE-RQ PDU to the peer

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -207,7 +207,7 @@ def AE_2(dul: "DULServiceProvider") -> str:
 
     # A-ASSOCIATE (RQ) primitive received from local user
     # primitive = cast("A_ASSOCIATE", dul.to_provider_queue.get(False))
-    primitive = dul._tmp
+    primitive = cast("A_ASSOCIATE", dul._tmp)
 
     # Send A-ASSOCIATE-RQ PDU to the peer
     pdu = A_ASSOCIATE_RQ()
@@ -336,15 +336,15 @@ def AE_6(dul: "DULServiceProvider") -> str:
     # Stop ARTIM timer
     dul.artim_timer.stop()
 
-    pdu = cast(A_ASSOCIATE_RQ, dul._recv_pdu.get(False))
-    primitive = cast("A_ASSOCIATE", pdu.to_primitive())
+    recv_pdu = cast(A_ASSOCIATE_RQ, dul._recv_pdu.get(False))
+    primitive = recv_pdu.to_primitive()
 
     # If A-ASSOCIATE-RQ not acceptable by service dul provider
     #   Then set reason and send -RJ PDU back to peer
-    if pdu.protocol_version != 0x0001:
+    if recv_pdu.protocol_version != 0x0001:
         LOGGER.error(
             "A-ASSOCIATE-RQ: Unsupported protocol version "
-            f"'0x{pdu.protocol_version:04X}'"
+            f"'0x{recv_pdu.protocol_version:04X}'"
         )
 
         # Send A-ASSOCIATE-RJ PDU and start ARTIM timer
@@ -573,7 +573,7 @@ def AR_3(dul: "DULServiceProvider") -> str:
     primitive = cast("A_RELEASE", pdu.to_primitive())
 
     # Issue A-RELEASE confirmation primitive and close transport connection
-    dul.to_user_queue.put(cast("A_RELEASE", primitive))
+    dul.to_user_queue.put(primitive)
     sock = cast("AssociationSocket", dul.socket)
     sock.close()
 
@@ -671,7 +671,7 @@ def AR_6(dul: "DULServiceProvider") -> str:
     """
     # P-DATA-TF PDU received from peer
     pdu = cast("P_DATA_TF", dul._recv_pdu.get(False))
-    primitive = cast("P_DATA", pdu.to_primitive())
+    primitive = pdu.to_primitive()
 
     # Issue P-DATA indication
     dul.to_user_queue.put(primitive)
@@ -731,7 +731,7 @@ def AR_8(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RQ PDU received from peer
     pdu = cast("A_RELEASE_RQ", dul._recv_pdu.get(False))
-    primitive = cast("A_RELEASE", pdu.to_primitive())
+    primitive = pdu.to_primitive()
 
     # Issue A-RELEASE indication (release collision)
     dul.to_user_queue.put(primitive)
@@ -791,7 +791,7 @@ def AR_10(dul: "DULServiceProvider") -> str:
     """
     # A-RELEASE-RP PDU received from peer
     pdu = cast("A_RELEASE_RP", dul._recv_pdu.get(False))
-    primitive = cast("A_RELEASE", pdu.to_primitive())
+    primitive = pdu.to_primitive()
 
     # Issue A-RELEASE confirmation primitive
     dul.to_user_queue.put(primitive)
@@ -821,7 +821,7 @@ def AA_1(dul: "DULServiceProvider") -> str:
     # Received invalid PDU from peer or an A-ABORT primitive from local user
     try:
         primitive = dul.to_provider_queue.queue[0]
-        if isinstance(primitive, A_ABORT):
+        if isinstance(primitive, (A_ABORT, A_P_ABORT)):
             primitive = dul.to_provider_queue.get(False)
     except (queue.Empty, IndexError):
         primitive = None

--- a/pynetdicom/pdu.py
+++ b/pynetdicom/pdu.py
@@ -1952,7 +1952,9 @@ class A_ABORT_RQ(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self, primitive: Optional["A_ABORT"] = None) -> None:
+    def __init__(
+        self, primitive: Optional[Union["A_ABORT", "A_P_ABORT"]] = None
+    ) -> None:
         """Initialise a new A-ABORT-RQ PDU.
 
         Parameters

--- a/pynetdicom/pdu.py
+++ b/pynetdicom/pdu.py
@@ -443,8 +443,14 @@ class A_ASSOCIATE_RQ(PDU):
       and :dcm:`9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-ASSOCIATE-RQ PDU."""
+    def __init__(self, primitive: Optional["A_ASSOCIATE"] = None) -> None:
+        """Initialise a new A-ASSOCIATE-RQ PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_ASSOCIATE
+            The primitive to use to initialise the PDU.
+        """
         # We allow the user to modify the protocol version if so desired
         self.protocol_version = 0x01
         self._called_aet = ""
@@ -460,6 +466,9 @@ class A_ASSOCIATE_RQ(PDU):
         #   1 UserInformationItem
         # The order of the items in the list may not be as given above
         self.variable_items: _PDUItemType = []
+
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     def from_primitive(self, primitive: "A_ASSOCIATE") -> None:
         """Setup the current PDU using an A-ASSOCIATE (request) primitive.
@@ -818,8 +827,14 @@ class A_ASSOCIATE_AC(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-ASSOCIATE-AC PDU."""
+    def __init__(self, primitive: Optional["A_ASSOCIATE"] = None) -> None:
+        """Initialise a new A-ASSOCIATE-AC PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_ASSOCIATE
+            The primitive to use to initialise the PDU.
+        """
         # We allow the user to modify the protocol version if so desired
         self.protocol_version = 0x01
         # Called AE Title, should be present, but no guarantees
@@ -833,6 +848,9 @@ class A_ASSOCIATE_AC(PDU):
         #   1 UserInformationItem
         # The order of the items in the list may not be as given above
         self.variable_items: _PDUItemType = []
+
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     def from_primitive(self, primitive: "A_ASSOCIATE") -> None:
         """Setup the current PDU using an A-ASSOCIATE (accept) primitive.
@@ -1197,11 +1215,20 @@ class A_ASSOCIATE_RJ(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-ASSOCIATE-RJ PDU."""
+    def __init__(self, primitive: Optional["A_ASSOCIATE"] = None) -> None:
+        """Initialise a new A-ASSOCIATE-RJ PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_ASSOCIATE
+            The primitive to use to initialise the PDU.
+        """
         self.result: Optional[int] = None
         self.source: Optional[int] = None
         self.reason_diagnostic: Optional[int] = None
+
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     def from_primitive(self, primitive: "A_ASSOCIATE") -> None:
         """Setup the current PDU using an A-ASSOCIATE (reject) primitive.
@@ -1412,9 +1439,18 @@ class P_DATA_TF(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new P-DATA-TF PDU."""
+    def __init__(self, primitive: Optional["P_DATA"] = None) -> None:
+        """Initialise a new P-DATA-TF PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.P_DATA
+            The primitive to use to initialise the PDU.
+        """
         self.presentation_data_value_items: _PDVItem = []
+
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     def from_primitive(self, primitive: "P_DATA") -> None:
         """Setup the current PDU using a P-DATA primitive.
@@ -1638,9 +1674,16 @@ class A_RELEASE_RQ(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-RELEASE-RQ PDU."""
-        pass
+    def __init__(self, primitive: Optional["A_RELEASE"] = None) -> None:
+        """Initialise a new A-RELEASE-RQ PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_RELEASE
+            The primitive to use to initialise the PDU.
+        """
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     @staticmethod
     def from_primitive(primitive: "A_RELEASE") -> None:
@@ -1763,9 +1806,16 @@ class A_RELEASE_RP(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-RELEASE-RP PDU."""
-        pass
+    def __init__(self, primitive: Optional["A_RELEASE"] = None) -> None:
+        """Initialise a new A-RELEASE-RP PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_RELEASE
+            The primitive to use to initialise the PDU.
+        """
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     @staticmethod
     def from_primitive(primitive: "A_RELEASE") -> None:
@@ -1902,10 +1952,19 @@ class A_ABORT_RQ(PDU):
       :dcm:`Section 9.3.1<part08/sect_9.3.html#sect_9.3.1>`
     """
 
-    def __init__(self) -> None:
-        """Initialise a new A-ABORT-RQ PDU."""
+    def __init__(self, primitive: Optional["A_ABORT"] = None) -> None:
+        """Initialise a new A-ABORT-RQ PDU.
+
+        Parameters
+        ----------
+        primitive : pynetdicom.pdu_primitive.A_ABORT
+            The primitive to use to initialise the PDU.
+        """
         self.source: Optional[int] = None
         self.reason_diagnostic: Optional[int] = None
+
+        if primitive is not None:
+            self.from_primitive(primitive)
 
     def from_primitive(self, primitive: _AbortType) -> None:
         """Setup the current PDU using an A-ABORT or A-P-ABORT primitive.

--- a/pynetdicom/tests/parrot.py
+++ b/pynetdicom/tests/parrot.py
@@ -197,7 +197,7 @@ class SteppingParrotRequest(ParrotRequest):
                 self.send(data)
                 self.sent.append(data)
 
-            LOGGER.debug("Parrent: step ending, event.clear()")
+            LOGGER.debug("Parrot: step ending, event.clear()")
             self.event.clear()
 
 

--- a/pynetdicom/tests/parrot.py
+++ b/pynetdicom/tests/parrot.py
@@ -1,6 +1,7 @@
 """The Parrot testing server."""
 
 import gc
+import logging
 import select
 import socket
 from socketserver import TCPServer, ThreadingMixIn, BaseRequestHandler
@@ -10,6 +11,9 @@ import threading
 import time
 
 from pynetdicom.transport import AssociationServer
+
+
+LOGGER = logging.getLogger("pynetdicom")
 
 
 class ParrotRequest(BaseRequestHandler):
@@ -171,27 +175,29 @@ class SteppingParrotRequest(ParrotRequest):
         self.received = []
         self.sent = []
         while True:
-            # print('Parrot: waiting on threading.Event')
+            LOGGER.debug("Parrot: waiting on event.wait()")
             self.event.wait()
-            # print('Parrot: wait ended')
+            LOGGER.debug("Parrot: event.wait() ended")
             cmd, data = self.commands.pop(0)
-            # print('Parrot: running command', cmd)
-            if cmd == "exit":
-                # print('Parrot: exiting...')
-                return
+            LOGGER.debug(f"Parrot: running command '{cmd}'")
 
-            if cmd == "recv":
-                # print('Parrot: receiving data')
+            if cmd == "exit":
+                LOGGER.debug("   Parrot: exiting...")
+                return
+            elif cmd == "recv":
+                LOGGER.debug("   Parrot: receiving data")
                 self.kill_read = False
                 while not self.kill_read:
                     if self.ready:
                         self.received.append(bytes(self.read_data))
                         self.kill_read = True
+                LOGGER.debug(f"  Parrot: received {len(self.received)} bytes")
             elif cmd == "send":
-                # print('Parrot: sending data')
+                LOGGER.debug("   Parrot: sending data")
                 self.send(data)
                 self.sent.append(data)
 
+            LOGGER.debug("Parrent: step ending, event.clear()")
             self.event.clear()
 
 
@@ -250,7 +256,7 @@ class Parrot(AssociationServer):
 
     def step(self):
         while self.event.is_set():
-            time.sleep(0.05)
+            time.sleep(0.0001)
 
         self.event.set()
 

--- a/pynetdicom/tests/test_acse.py
+++ b/pynetdicom/tests/test_acse.py
@@ -55,7 +55,7 @@ from .encoded_pdu_items import (
 from .parrot import ThreadedParrot, ParrotRequest
 
 
-# debug_logger()
+debug_logger()
 
 
 class DummyAssociationSocket:

--- a/pynetdicom/tests/test_acse.py
+++ b/pynetdicom/tests/test_acse.py
@@ -55,7 +55,7 @@ from .encoded_pdu_items import (
 from .parrot import ThreadedParrot, ParrotRequest
 
 
-debug_logger()
+# debug_logger()
 
 
 class DummyAssociationSocket:

--- a/pynetdicom/tests/test_dul.py
+++ b/pynetdicom/tests/test_dul.py
@@ -270,11 +270,15 @@ class TestDUL:
         assert assoc.is_established
 
         scp.step()  # send bad PDU
-        scp.step()  # receive abort
-        assert assoc.is_aborted
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
+        scp.step()  # receive abort
         scp.step()
         scp.shutdown()
+
+        assert assoc.is_aborted
 
     def test_exception_in_reactor(self):
         """Test that an exception being raised in the DUL reactor kills the
@@ -310,7 +314,12 @@ class TestDUL:
         assoc.dul._read_pdu_data = patch_read_pdu
 
         scp.step()
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
+
         assert assoc.is_aborted
 
         scp.step()

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -24,7 +24,7 @@ from pynetdicom.pdu_primitives import (
     ImplementationClassUIDNotification,
 )
 from pynetdicom.sop_class import Verification
-from pynetdicom.transport import AssociationSocket
+from pynetdicom.transport import AssociationSocket, T_CONNECT
 from .encoded_pdu_items import (
     a_associate_ac,
     a_associate_rq,
@@ -1823,7 +1823,8 @@ class TestState04(TestStateBase):
     """Tests for State 04: Awaiting TRANSPORT_OPEN from <transport service>."""
 
     def move_to_state(self, assoc, scp):
-        def connect(address):
+        def connect(primitive):
+            address = primitive.address
             """Override the socket's connect so no event gets added."""
             if assoc.dul.socket.socket is None:
                 assoc.dul.socket.socket = assoc.dul.socket._create_socket()
@@ -8783,9 +8784,9 @@ class TestStateMachineFunctionalAcceptor:
         assert self.fsm.current_state == "Sta1"
 
         def AE_2(dul):
-            primitive = dul._tmp
+            conn = dul.to_provider_queue.get(False)
             pdu = A_ASSOCIATE_RQ()
-            pdu.from_primitive(primitive)
+            pdu.from_primitive(conn.request)
             pdu.protocol_version = 0x0002
             bytestream = pdu.encode()
             dul.socket.send(bytestream)

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -401,14 +401,19 @@ class TestStateBase:
         fsm = self.monkey_patch(assoc.dul.state_machine)
         return assoc, fsm
 
-    def wait_on_state(self, fsm, state, timeout=5):
+    def wait_on_state(self, fsm, state, timeout=2):
         start = 0
         while fsm.current_state != state and start < timeout:
-            time.sleep(0.05)
-            start += 0.05
+            time.sleep(0.0001)
+            start += 0.0001
+
+        # if start >= timeout:
+        #     print(f"'wait_on_state' timed out for state {state}")
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
+IGNORE_FILTER = "ignore:.*:pytest.PytestUnhandledThreadExceptionWarning"
+
+
 class TestState01(TestStateBase):
     """Tests for State 01: Idle."""
 
@@ -443,6 +448,7 @@ class TestState01(TestStateBase):
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt03(self):
         """Test Sta1 + Evt3."""
         # Sta1 + Evt3 -> <ignore> -> Sta1
@@ -463,6 +469,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt3"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt04(self):
         """Test Sta1 + Evt4."""
         # Sta1 + Evt4 -> <ignore> -> Sta1
@@ -492,6 +499,7 @@ class TestState01(TestStateBase):
         #       Start ARTIM timer
         pass
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt06(self):
         """Test Sta1 + Evt6."""
         # Sta1 + Evt6 -> <ignore> -> Sta1
@@ -512,6 +520,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt6"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta1 + Evt7."""
         # Sta1 + Evt7 -> <ignore> -> Sta1
@@ -529,6 +538,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[0] == "Evt7"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta1 + Evt8."""
         # Sta1 + Evt8 -> <ignore> -> Sta1
@@ -547,6 +557,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt8"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta1 + Evt9."""
         # Sta1 + Evt9 -> <ignore> -> Sta1
@@ -565,6 +576,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt9"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt10(self):
         """Test Sta1 + Evt10."""
         # Sta1 + Evt10 -> <ignore> -> Sta1
@@ -585,6 +597,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta1 + Evt11."""
         # Sta1 + Evt11 -> <ignore> -> Sta1
@@ -603,6 +616,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt11"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt12(self):
         """Test Sta1 + Evt12."""
         # Sta1 + Evt12 -> <ignore> -> Sta1
@@ -623,6 +637,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt12"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt13(self):
         """Test Sta1 + Evt13."""
         # Sta1 + Evt13 -> <ignore> -> Sta1
@@ -643,6 +658,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta1 + Evt14."""
         # Sta1 + Evt14 -> <ignore> -> Sta1
@@ -661,6 +677,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt14"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt15(self):
         """Test Sta1 + Evt15."""
         # Sta1 + Evt15 -> <ignore> -> Sta1
@@ -679,6 +696,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt15"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt16(self):
         """Test Sta1 + Evt16."""
         # Sta1 + Evt16 -> <ignore> -> Sta1
@@ -699,6 +717,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt16"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt17(self):
         """Test Sta1 + Evt17."""
         # Sta1 + Evt17 -> <ignore> -> Sta1
@@ -720,6 +739,7 @@ class TestState01(TestStateBase):
         assert self.fsm._changes == []
         assert self.fsm._events[:1] == ["Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta1 + Evt18."""
         # Sta1 + Evt18 -> <ignore> -> Sta1
@@ -740,6 +760,7 @@ class TestState01(TestStateBase):
         assert self.fsm._events[0] == "Evt18"
         assert self.fsm.current_state == "Sta1"
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt19(self):
         """Test Sta1 + Evt19."""
         # Sta1 + Evt19 -> <ignore> -> Sta1
@@ -761,7 +782,6 @@ class TestState01(TestStateBase):
         assert self.fsm._events[:1] == ["Evt19"]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState02(TestStateBase):
     """Tests for State 02: Connection open, waiting for A-ASSOCIATE-RQ."""
 
@@ -769,6 +789,7 @@ class TestState02(TestStateBase):
         assoc.start()
         self.wait_on_state(assoc.dul.state_machine, "Sta2")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta2 + Evt1."""
         # Sta2 + Evt1 -> <ignore> -> Sta2
@@ -881,6 +902,7 @@ class TestState02(TestStateBase):
         assert fsm._changes[:2] == [("Sta1", "Evt5", "AE-5"), ("Sta2", "Evt6", "AE-6")]
         assert fsm._events[:2] == ["Evt5", "Evt6"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta2 + Evt7."""
         # Sta2 + Evt7 -> <ignore> -> Sta2
@@ -901,6 +923,7 @@ class TestState02(TestStateBase):
         ]
         assert fsm._events[:2] == ["Evt5", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta2 + Evt8."""
         # Sta2 + Evt8 -> <ignore> -> Sta2
@@ -921,6 +944,7 @@ class TestState02(TestStateBase):
         ]
         assert fsm._events[:2] == ["Evt5", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta2 + Evt9."""
         # Sta2 + Evt9 -> <ignore> -> Sta2
@@ -961,6 +985,7 @@ class TestState02(TestStateBase):
         assert fsm._changes[:2] == [("Sta1", "Evt5", "AE-5"), ("Sta2", "Evt10", "AA-1")]
         assert fsm._events[:2] == ["Evt5", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta2 + Evt11."""
         # Sta2 + Evt11 -> <ignore> -> Sta2
@@ -1020,6 +1045,7 @@ class TestState02(TestStateBase):
         assert fsm._changes[:2] == [("Sta1", "Evt5", "AE-5"), ("Sta2", "Evt13", "AA-1")]
         assert fsm._events[:2] == ["Evt5", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta2 + Evt14."""
         # Sta2 + Evt14 -> <ignore> -> Sta2
@@ -1041,6 +1067,7 @@ class TestState02(TestStateBase):
         ]
         assert fsm._events[:2] == ["Evt5", "Evt14"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt15(self):
         """Test Sta2 + Evt15."""
         # Sta2 + Evt15 -> <ignore> -> Sta2
@@ -1140,7 +1167,6 @@ class TestState02(TestStateBase):
         assert fsm._events[:2] == ["Evt5", "Evt19"]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState03(TestStateBase):
     """Tests for State 03: Awaiting A-ASSOCIATE (rsp) primitive."""
 
@@ -1149,6 +1175,7 @@ class TestState03(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta3")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta3 + Evt1."""
         # Sta3 + Evt1 -> <ignore> -> Sta3
@@ -1342,6 +1369,7 @@ class TestState03(TestStateBase):
         ]
         assert fsm._events[:3] == ["Evt5", "Evt6", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta3 + Evt9."""
         # Sta3 + Evt9 -> <ignore> -> Sta3
@@ -1403,6 +1431,7 @@ class TestState03(TestStateBase):
         ]
         assert fsm._events[:3] == ["Evt5", "Evt6", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta3 + Evt11."""
         # Sta3 + Evt11 -> <ignore> -> Sta3
@@ -1497,6 +1526,7 @@ class TestState03(TestStateBase):
         ]
         assert fsm._events[:3] == ["Evt5", "Evt6", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta3 + Evt14."""
         # Sta3 + Evt14 -> <ignore> -> Sta3
@@ -1622,6 +1652,7 @@ class TestState03(TestStateBase):
         ]
         assert fsm._events[:3] == ["Evt5", "Evt6", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta3 + Evt18."""
         # Sta3 + Evt18 -> <ignore> -> Sta3
@@ -1692,7 +1723,6 @@ class TestState03(TestStateBase):
         assert fsm._events[:3] == ["Evt5", "Evt6", "Evt19"]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState04(TestStateBase):
     """Tests for State 04: Awaiting TRANSPORT_OPEN from <transport service>."""
 
@@ -1713,6 +1743,7 @@ class TestState04(TestStateBase):
         assoc.start()
         self.wait_on_state(assoc.dul.state_machine, "Sta4")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta4 + Evt1."""
         # Sta4 + Evt1 -> <ignore> -> Sta4
@@ -1739,6 +1770,7 @@ class TestState04(TestStateBase):
         # Evt2: Receive TRANSPORT_OPEN from <transport service>
         pass
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt03(self):
         """Test Sta4 + Evt3."""
         # Sta4 + Evt3 -> <ignore> -> Sta4
@@ -1757,6 +1789,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt3"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt04(self):
         """Test Sta4 + Evt4."""
         # Sta4 + Evt4 -> <ignore> -> Sta4
@@ -1784,6 +1817,7 @@ class TestState04(TestStateBase):
         #       Start ARTIM timer
         pass
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt06(self):
         """Test Sta4 + Evt6."""
         # Sta4 + Evt6 -> <ignore> -> Sta4
@@ -1802,6 +1836,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt6"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta4 + Evt7."""
         # Sta4 + Evt7 -> <ignore> -> Sta4
@@ -1821,6 +1856,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta4 + Evt8."""
         # Sta4 + Evt8 -> <ignore> -> Sta4
@@ -1840,6 +1876,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta4 + Evt9."""
         # Sta4 + Evt9 -> <ignore> -> Sta4
@@ -1859,6 +1896,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt9"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt10(self):
         """Test Sta4 + Evt10."""
         # Sta4 + Evt10 -> <ignore> -> Sta4
@@ -1877,6 +1915,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta4 + Evt11."""
         # Sta4 + Evt11 -> <ignore> -> Sta4
@@ -1896,6 +1935,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt11"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt12(self):
         """Test Sta4 + Evt12."""
         # Sta4 + Evt12 -> <ignore> -> Sta4
@@ -1914,6 +1954,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt12"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt13(self):
         """Test Sta4 + Evt13."""
         # Sta4 + Evt13 -> <ignore> -> Sta4
@@ -1932,6 +1973,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta4 + Evt14."""
         # Sta4 + Evt14 -> <ignore> -> Sta4
@@ -1951,6 +1993,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt14"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt15(self):
         """Test Sta4 + Evt15."""
         # Sta4 + Evt15 -> <ignore> -> Sta4
@@ -1970,6 +2013,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt15"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt16(self):
         """Test Sta4 + Evt16."""
         # Sta4 + Evt16 -> <ignore> -> Sta4
@@ -1988,6 +2032,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt16"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt17(self):
         """Test Sta4 + Evt17."""
         # Sta4 + Evt17 -> <ignore> -> Sta4
@@ -2007,6 +2052,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta4 + Evt18."""
         # Sta4 + Evt18 -> <ignore> -> Sta4
@@ -2028,6 +2074,7 @@ class TestState04(TestStateBase):
         ]
         assert self.fsm._events[:2] == ["Evt1", "Evt18"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt19(self):
         """Test Sta4 + Evt19."""
         # Sta4 + Evt19 -> <ignore> -> Sta4
@@ -2047,7 +2094,6 @@ class TestState04(TestStateBase):
         assert self.fsm._events[:2] == ["Evt1", "Evt19"]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState05(TestStateBase):
     """Tests for State 05: Awaiting A-ASSOCIATE-AC or A-ASSOCIATE-RJ PDU."""
 
@@ -2056,6 +2102,7 @@ class TestState05(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta5")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta5 + Evt1."""
         # Sta5 + Evt1 -> <ignore> -> Sta5
@@ -2164,6 +2211,7 @@ class TestState05(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta5 + Evt7."""
         # Sta5 + Evt7 -> <ignore> -> Sta5
@@ -2184,6 +2232,7 @@ class TestState05(TestStateBase):
         assert self.fsm._transitions[:2] == ["Sta4", "Sta5"]
         assert self.fsm._events[:3] == ["Evt1", "Evt2", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta5 + Evt8."""
         # Sta5 + Evt8 -> <ignore> -> Sta5
@@ -2204,6 +2253,7 @@ class TestState05(TestStateBase):
         assert self.fsm._transitions[:2] == ["Sta4", "Sta5"]
         assert self.fsm._events[:3] == ["Evt1", "Evt2", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta5 + Evt9."""
         # Sta5 + Evt9 -> <ignore> -> Sta5
@@ -2251,6 +2301,7 @@ class TestState05(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta5 + Evt11."""
         # Sta5 + Evt11 -> <ignore> -> Sta5
@@ -2333,6 +2384,7 @@ class TestState05(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta5 + Evt14."""
         # Sta5 + Evt14 -> <ignore> -> Sta5
@@ -2427,6 +2479,7 @@ class TestState05(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta1"]
         assert self.fsm._events[:3] == ["Evt1", "Evt2", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta5 + Evt18."""
         # Sta5 + Evt18 -> <ignore> -> Sta5
@@ -2481,7 +2534,6 @@ class TestState05(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState06(TestStateBase):
     """Tests for State 06: Association established and ready for data."""
 
@@ -2491,6 +2543,7 @@ class TestState06(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta6")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta6 + Evt1."""
         # Sta6 + Evt1 -> <ignore> -> Sta6
@@ -2628,6 +2681,7 @@ class TestState06(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta6 + Evt7."""
         # Sta6 + Evt7 -> <ignore> -> Sta6
@@ -2649,6 +2703,7 @@ class TestState06(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta6"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt3", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta6 + Evt8."""
         # Sta6 + Evt8 -> <ignore> -> Sta6
@@ -2802,6 +2857,7 @@ class TestState06(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta6 + Evt14."""
         # Sta6 + Evt14 -> <ignore> -> Sta6
@@ -2907,6 +2963,7 @@ class TestState06(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta1"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt3", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta6 + Evt18."""
         # Sta6 + Evt18 -> <ignore> -> Sta6
@@ -2965,7 +3022,6 @@ class TestState06(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState07(TestStateBase):
     """Tests for State 07: Awaiting A-RELEASE-RP PDU."""
 
@@ -2978,6 +3034,7 @@ class TestState07(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta7")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta7 + Evt1."""
         # Sta7 + Evt1 -> <ignore> -> Sta7
@@ -3127,6 +3184,7 @@ class TestState07(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta7 + Evt7."""
         # Sta7 + Evt7 -> <ignore> -> Sta7
@@ -3154,6 +3212,7 @@ class TestState07(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta7"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt11", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta7 + Evt8."""
         # Sta7 + Evt8 -> <ignore> -> Sta7
@@ -3181,6 +3240,7 @@ class TestState07(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta7"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt11", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta7 + Evt9."""
         # Sta7 + Evt9 -> <ignore> -> Sta7
@@ -3239,6 +3299,7 @@ class TestState07(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta7"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt11", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta7 + Evt11."""
         # Sta7 + Evt11 -> <ignore> -> Sta7
@@ -3326,6 +3387,7 @@ class TestState07(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta7"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt11", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta7 + Evt14."""
         # Sta7 + Evt14 -> <ignore> -> Sta7
@@ -3442,6 +3504,7 @@ class TestState07(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta7"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt11", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta7 + Evt18."""
         # Sta7 + Evt18 -> <ignore> -> Sta7
@@ -3508,7 +3571,6 @@ class TestState07(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState08(TestStateBase):
     """Tests for State 08: Awaiting A-RELEASE (rp) primitive."""
 
@@ -3526,6 +3588,7 @@ class TestState08(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta8")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta8 + Evt1."""
         # Sta8 + Evt1 -> <ignore> -> Sta8
@@ -3654,6 +3717,7 @@ class TestState08(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta8"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt12", "Evt6"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta8 + Evt7."""
         # Sta8 + Evt7 -> <ignore> -> Sta8
@@ -3681,6 +3745,7 @@ class TestState08(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta8"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt12", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta8 + Evt8."""
         # Sta8 + Evt8 -> <ignore> -> Sta8
@@ -3765,6 +3830,7 @@ class TestState08(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta8"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt12", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta8 + Evt11."""
         # Sta8 + Evt11 -> <ignore> -> Sta8
@@ -3967,6 +4033,7 @@ class TestState08(TestStateBase):
         assert self.fsm._transitions[:4] == ["Sta4", "Sta5", "Sta6", "Sta8"]
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt12", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta8 + Evt18."""
         # Sta8 + Evt18 -> <ignore> -> Sta1
@@ -4026,7 +4093,6 @@ class TestState08(TestStateBase):
         assert self.fsm._events[:5] == ["Evt1", "Evt2", "Evt3", "Evt12", "Evt19"]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState09(TestStateBase):
     """Tests for State 09: Release collision req - awaiting A-RELEASE (rp)."""
 
@@ -4046,6 +4112,7 @@ class TestState09(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta9")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta9 + Evt1."""
         # Sta9 + Evt1 -> <ignore> -> Sta9
@@ -4225,6 +4292,7 @@ class TestState09(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta9 + Evt7."""
         # Sta9 + Evt7 -> <ignore> -> Sta9
@@ -4261,6 +4329,7 @@ class TestState09(TestStateBase):
             "Evt7",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta9 + Evt8."""
         # Sta9 + Evt8 -> <ignore> -> Sta9
@@ -4297,6 +4366,7 @@ class TestState09(TestStateBase):
             "Evt8",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta9 + Evt9."""
         # Sta9 + Evt9 -> <ignore> -> Sta9
@@ -4376,6 +4446,7 @@ class TestState09(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta9 + Evt11."""
         # Sta9 + Evt11 -> <ignore> -> Sta9
@@ -4659,6 +4730,7 @@ class TestState09(TestStateBase):
             "Evt17",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta9 + Evt18."""
         # Sta9 + Evt18 -> <ignore> -> Sta9
@@ -4741,7 +4813,6 @@ class TestState09(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState10(TestStateBase):
     """Tests for State 10: Release collision acc - awaiting A-RELEASE-RP ."""
 
@@ -4761,6 +4832,7 @@ class TestState10(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta10")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta10 + Evt1."""
         # Sta10 + Evt1 -> <ignore> -> Sta10
@@ -4916,6 +4988,7 @@ class TestState10(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta10 + Evt7."""
         # Sta10 + Evt7 -> <ignore> -> Sta10
@@ -4946,6 +5019,7 @@ class TestState10(TestStateBase):
         ]
         assert fsm._events[:6] == ["Evt5", "Evt6", "Evt7", "Evt11", "Evt12", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta10 + Evt8."""
         # Sta10 + Evt8 -> <ignore> -> Sta10
@@ -4976,6 +5050,7 @@ class TestState10(TestStateBase):
         ]
         assert fsm._events[:6] == ["Evt5", "Evt6", "Evt7", "Evt11", "Evt12", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta10 + Evt9."""
         # Sta10 + Evt9 -> <ignore> -> Sta10
@@ -5043,6 +5118,7 @@ class TestState10(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta10 + Evt11."""
         # Sta10 + Evt11 -> <ignore> -> Sta10
@@ -5142,6 +5218,7 @@ class TestState10(TestStateBase):
         ]
         assert fsm._events[:6] == ["Evt5", "Evt6", "Evt7", "Evt11", "Evt12", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta10 + Evt14."""
         # Sta10 + Evt14 -> <ignore> -> Sta10
@@ -5273,6 +5350,7 @@ class TestState10(TestStateBase):
         ]
         assert fsm._events[:6] == ["Evt5", "Evt6", "Evt7", "Evt11", "Evt12", "Evt17"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta10 + Evt18."""
         # Sta10 + Evt18 -> <ignore> -> Sta10
@@ -5343,7 +5421,6 @@ class TestState10(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState11(TestStateBase):
     """Tests for State 11: Release collision req - awaiting A-RELEASE-RP PDU"""
 
@@ -5365,6 +5442,7 @@ class TestState11(TestStateBase):
         assoc.dul.send_pdu(self.get_release(True))
         self.wait_on_state(assoc.dul.state_machine, "Sta11")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta11 + Evt1."""
         # Sta11 + Evt1 -> <ignore> -> Sta11
@@ -5578,6 +5656,7 @@ class TestState11(TestStateBase):
             "Evt6",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta11 + Evt7."""
         # Sta11 + Evt7 -> <ignore> -> Sta11
@@ -5625,6 +5704,7 @@ class TestState11(TestStateBase):
             "Evt7",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta11 + Evt8."""
         # Sta11 + Evt8 -> <ignore> -> Sta11
@@ -5672,6 +5752,7 @@ class TestState11(TestStateBase):
             "Evt8",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta11 + Evt9."""
         # Sta11 + Evt9 -> <ignore> -> Sta11
@@ -5770,6 +5851,7 @@ class TestState11(TestStateBase):
             "Evt10",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta11 + Evt11."""
         # Sta11 + Evt11 -> <ignore> -> Sta11
@@ -5917,6 +5999,7 @@ class TestState11(TestStateBase):
             "Evt13",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta11 + Evt14."""
         # Sta11 + Evt14 -> <ignore> -> Sta11
@@ -6113,6 +6196,7 @@ class TestState11(TestStateBase):
             "Evt17",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta11 + Evt18."""
         # Sta11 + Evt18 -> <ignore> -> Sta11
@@ -6207,7 +6291,6 @@ class TestState11(TestStateBase):
         ]
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState12(TestStateBase):
     """Tests for State 12: Release collision acc - awaiting A-RELEASE (rp)"""
 
@@ -6229,6 +6312,7 @@ class TestState12(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta12")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta12 + Evt1."""
         # Sta12 + Evt1 -> <ignore> -> Sta12
@@ -6451,6 +6535,7 @@ class TestState12(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta12 + Evt7."""
         # Sta12 + Evt7 -> <ignore> -> Sta12
@@ -6498,6 +6583,7 @@ class TestState12(TestStateBase):
             "Evt7",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta12 + Evt8."""
         # Sta12 + Evt8 -> <ignore> -> Sta12
@@ -6545,6 +6631,7 @@ class TestState12(TestStateBase):
             "Evt8",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta12 + Evt9."""
         # Sta12 + Evt9 -> <ignore> -> Sta12
@@ -6646,6 +6733,7 @@ class TestState12(TestStateBase):
             b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x00"
         )
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta12 + Evt11."""
         # Sta12 + Evt11 -> <ignore> -> Sta12
@@ -7005,6 +7093,7 @@ class TestState12(TestStateBase):
             "Evt17",
         ]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt18(self):
         """Test Sta12 + Evt18."""
         # Sta12 + Evt18 -> <ignore> -> Sta12
@@ -7109,7 +7198,6 @@ class TestState12(TestStateBase):
         )
 
 
-@pytest.mark.filterwarnings("ignore:.*:pytest.PytestUnhandledThreadExceptionWarning")
 class TestState13(TestStateBase):
     """Tests for State 13: Waiting for connection closed."""
 
@@ -7139,6 +7227,7 @@ class TestState13(TestStateBase):
         scp.step()
         self.wait_on_state(assoc.dul.state_machine, "Sta13")
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt01(self):
         """Test Sta13 + Evt1."""
         # Sta13 + Evt1 -> <ignore> -> Sta13
@@ -7273,6 +7362,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt6"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt07(self):
         """Test Sta13 + Evt7."""
         # Sta13 + Evt7 -> <ignore> -> Sta13
@@ -7298,6 +7388,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt7"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt08(self):
         """Test Sta13 + Evt8."""
         # Sta13 + Evt8 -> <ignore> -> Sta13
@@ -7323,6 +7414,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt8"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt09(self):
         """Test Sta13 + Evt9."""
         # Sta13 + Evt9 -> <ignore> -> Sta13
@@ -7375,6 +7467,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt10"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt11(self):
         """Test Sta13 + Evt11."""
         # Sta13 + Evt11 -> <ignore> -> Sta13
@@ -7454,6 +7547,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt13"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt14(self):
         """Test Sta13 + Evt14."""
         # Sta13 + Evt14 -> <ignore> -> Sta13
@@ -7479,6 +7573,7 @@ class TestState13(TestStateBase):
         assert self.fsm._transitions[:3] == ["Sta4", "Sta5", "Sta13"]
         assert self.fsm._events[:4] == ["Evt1", "Evt2", "Evt6", "Evt14"]
 
+    @pytest.mark.filterwarnings(IGNORE_FILTER)
     def test_evt15(self):
         """Test Sta13 + Evt15."""
         # Sta13 + Evt15 -> <ignore> -> Sta13

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -37,7 +37,7 @@ from .encoded_pdu_items import (
 from .parrot import ThreadedParrot
 
 
-debug_logger()
+# debug_logger()
 
 
 REFERENCE_BAD_EVENTS = [

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -8156,10 +8156,11 @@ class TestStateMachineFunctionalRequestor:
             dul.socket.send(p_data_tf)
 
             # Normal release response
-            dul.pdu = A_RELEASE_RP()
-            dul.pdu.from_primitive(dul.primitive)
+            primitive = dul.to_provider_queue.get(False)
+            pdu = A_RELEASE_RP()
+            pdu.from_primitive(primitive)
             # Callback
-            dul.socket.send(dul.pdu.encode())
+            dul.socket.send(pdu.encode())
             dul.artim_timer.start()
             return "Sta13"
 
@@ -8226,8 +8227,11 @@ class TestStateMachineFunctionalRequestor:
             # Send C-ECHO request to the peer via DIMSE and wait for the response
             dul.assoc.dimse.send_msg(primitive, 1)
 
+            pdu = dul._recv_pdu.get(False)
+            primitive = pdu.to_primitive()
+
             # Normal AR2 response
-            dul.to_user_queue.put(dul.primitive)
+            dul.to_user_queue.put(primitive)
             return "Sta8"
 
         # In this case the association acceptor will hit AR_2
@@ -8361,10 +8365,11 @@ class TestStateMachineFunctionalAcceptor:
         assert self.fsm.current_state == "Sta1"
 
         def AE_2(dul):
-            dul.pdu = A_ASSOCIATE_RQ()
-            dul.pdu.from_primitive(dul.primitive)
-            dul.pdu.protocol_version = 0x0002
-            bytestream = dul.pdu.encode()
+            primitive = dul._tmp
+            pdu = A_ASSOCIATE_RQ()
+            pdu.from_primitive(primitive)
+            pdu.protocol_version = 0x0002
+            bytestream = pdu.encode()
             dul.socket.send(bytestream)
             return "Sta5"
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -37,7 +37,7 @@ from .encoded_pdu_items import (
 from .parrot import ThreadedParrot
 
 
-# debug_logger()
+debug_logger()
 
 
 REFERENCE_BAD_EVENTS = [
@@ -462,6 +462,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -483,6 +487,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -513,6 +521,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -528,9 +540,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -546,9 +561,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -565,9 +583,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_pdata())
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -590,6 +611,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -605,9 +630,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_release(False))
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -630,6 +658,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -651,6 +683,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -666,9 +702,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_release(True))
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -685,9 +724,12 @@ class TestState01(TestStateBase):
         self.assoc._mode = "acceptor"
         self.assoc.start()
 
+        time.sleep(0.1)
+
         self.assoc.dul.send_pdu(self.get_abort(False))
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -710,6 +752,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -733,7 +779,8 @@ class TestState01(TestStateBase):
         scp.step()
         scp.shutdown()
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         assert self.fsm._transitions == []
         assert self.fsm._changes == []
@@ -746,10 +793,14 @@ class TestState01(TestStateBase):
         # Evt18: ARTIM timer expired from <local service>
         self.assoc._mode = "acceptor"
         self.assoc.start()
+
+        time.sleep(0.1)
+
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         self.assoc.kill()
 
@@ -774,6 +825,10 @@ class TestState01(TestStateBase):
         self.assoc.dul.socket._is_connected = True
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -800,6 +855,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_associate("request"))
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -914,6 +972,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
         assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -934,6 +995,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_associate("reject"))
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -956,6 +1020,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_pdata())
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -997,6 +1064,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_release(False))
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1058,6 +1128,9 @@ class TestState02(TestStateBase):
 
         assoc.dul.send_pdu(self.get_release(True))
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1079,6 +1152,9 @@ class TestState02(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_abort())
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1193,6 +1269,9 @@ class TestState03(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1388,6 +1467,9 @@ class TestState03(TestStateBase):
         assoc.acse._negotiate_as_acceptor = _neg_as_acc
         self.move_to_state(assoc, scp)
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1449,6 +1531,9 @@ class TestState03(TestStateBase):
 
         assoc.acse._negotiate_as_acceptor = _neg_as_acc
         self.move_to_state(assoc, scp)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1544,6 +1629,9 @@ class TestState03(TestStateBase):
 
         assoc.acse._negotiate_as_acceptor = _neg_as_acc
         self.move_to_state(assoc, scp)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1676,6 +1764,9 @@ class TestState03(TestStateBase):
         assoc.acse._negotiate_as_acceptor = _neg_as_acc
         self.move_to_state(assoc, scp)
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.shutdown()
 
         assert fsm._transitions[:2] == ["Sta2", "Sta3"]
@@ -1754,6 +1845,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1780,6 +1874,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1799,6 +1897,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1827,6 +1929,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1846,6 +1952,9 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -1867,6 +1976,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1887,6 +1999,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_pdata())
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1906,6 +2021,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1926,6 +2045,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_release(False))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1945,6 +2067,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1964,6 +2090,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -1983,6 +2113,9 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(True))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2004,6 +2137,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_abort())
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2023,6 +2159,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2044,7 +2184,8 @@ class TestState04(TestStateBase):
         scp.step()
         scp.shutdown()
 
-        time.sleep(0.5)
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         assert self.fsm._transitions[:1] == ["Sta4"]
         assert self.fsm._changes[:1] == [
@@ -2063,7 +2204,9 @@ class TestState04(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2084,6 +2227,10 @@ class TestState04(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         scp.step()
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2112,6 +2259,9 @@ class TestState05(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2222,6 +2372,9 @@ class TestState05(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2243,6 +2396,9 @@ class TestState05(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2263,6 +2419,9 @@ class TestState05(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2311,6 +2470,9 @@ class TestState05(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2394,6 +2556,9 @@ class TestState05(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(True))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2490,7 +2655,9 @@ class TestState05(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2553,6 +2720,9 @@ class TestState06(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2692,6 +2862,9 @@ class TestState06(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2713,6 +2886,9 @@ class TestState06(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -2868,6 +3044,9 @@ class TestState06(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_release(True))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -2974,7 +3153,9 @@ class TestState06(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3049,6 +3230,9 @@ class TestState07(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3200,6 +3384,9 @@ class TestState07(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -3228,6 +3415,9 @@ class TestState07(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -3255,6 +3445,9 @@ class TestState07(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3314,6 +3507,9 @@ class TestState07(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3402,6 +3598,9 @@ class TestState07(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(True))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3520,7 +3719,9 @@ class TestState07(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3603,6 +3804,9 @@ class TestState08(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3733,6 +3937,9 @@ class TestState08(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -3760,6 +3967,9 @@ class TestState08(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -3845,6 +4055,9 @@ class TestState08(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4049,7 +4262,9 @@ class TestState08(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4128,6 +4343,9 @@ class TestState09(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4309,6 +4527,9 @@ class TestState09(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -4346,6 +4567,9 @@ class TestState09(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -4382,6 +4606,9 @@ class TestState09(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4462,6 +4689,9 @@ class TestState09(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4747,7 +4977,9 @@ class TestState09(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -4849,6 +5081,9 @@ class TestState10(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -5006,6 +5241,9 @@ class TestState10(TestStateBase):
 
         assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -5037,6 +5275,9 @@ class TestState10(TestStateBase):
 
         assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -5067,6 +5308,9 @@ class TestState10(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -5135,6 +5379,9 @@ class TestState10(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -5235,6 +5482,9 @@ class TestState10(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_release(True))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -5368,7 +5618,9 @@ class TestState10(TestStateBase):
 
         assoc.dul.artim_timer.timeout = 0.05
         assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -5458,6 +5710,9 @@ class TestState11(TestStateBase):
         self.scp = scp = self.start_server(commands)
         self.move_to_state(self.assoc, scp)
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.step()
@@ -5674,6 +5929,9 @@ class TestState11(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.step()
         scp.shutdown()
@@ -5722,6 +5980,9 @@ class TestState11(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.step()
         scp.shutdown()
@@ -5769,6 +6030,9 @@ class TestState11(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.step()
@@ -5868,6 +6132,9 @@ class TestState11(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.step()
@@ -6016,6 +6283,9 @@ class TestState11(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(True))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.step()
@@ -6214,7 +6484,9 @@ class TestState11(TestStateBase):
 
         self.assoc.dul.artim_timer.timeout = 0.05
         self.assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.step()
@@ -6329,6 +6601,9 @@ class TestState12(TestStateBase):
         assoc, fsm = self.get_acceptor_assoc()
         self.move_to_state(assoc, scp)
         assoc.dul.send_pdu(self.get_associate("request"))
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -6554,6 +6829,9 @@ class TestState12(TestStateBase):
 
         assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -6602,6 +6880,9 @@ class TestState12(TestStateBase):
 
         assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -6649,6 +6930,9 @@ class TestState12(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_pdata())
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -6751,6 +7035,9 @@ class TestState12(TestStateBase):
         self.move_to_state(assoc, scp)
 
         assoc.dul.send_pdu(self.get_release(False))
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7112,7 +7399,9 @@ class TestState12(TestStateBase):
 
         assoc.dul.artim_timer.timeout = 0.05
         assoc.dul.artim_timer.start()
-        time.sleep(0.5)
+
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7241,6 +7530,9 @@ class TestState13(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_associate("request"))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7377,6 +7669,9 @@ class TestState13(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("accept"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -7403,6 +7698,9 @@ class TestState13(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_associate("reject"))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -7428,6 +7726,9 @@ class TestState13(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_pdata())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7481,6 +7782,9 @@ class TestState13(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_release(False))
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7562,6 +7866,9 @@ class TestState13(TestStateBase):
 
         self.assoc.dul.send_pdu(self.get_release(True))
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
         scp.step()
         scp.shutdown()
 
@@ -7587,6 +7894,9 @@ class TestState13(TestStateBase):
         self.move_to_state(self.assoc, scp)
 
         self.assoc.dul.send_pdu(self.get_abort())
+
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
 
         scp.step()
         scp.shutdown()
@@ -7741,9 +8051,13 @@ class TestParrotAttack(TestStateBase):
         self.scp = scp = self.start_server(commands)
         self.assoc.start()
 
-        for ii in range(len(commands)):
+        for ii in range(len(commands) - 1):
             scp.step()
 
+        while self.assoc.dul.is_alive():
+            time.sleep(0.001)
+
+        scp.step()
         scp.shutdown()
 
         assert self.fsm._changes[:14] == [
@@ -7816,9 +8130,13 @@ class TestParrotAttack(TestStateBase):
         assoc, fsm = self.get_acceptor_assoc()
         assoc.start()
 
-        for ii in range(len(commands)):
+        for ii in range(len(commands) - 1):
             scp.step()
 
+        while assoc.dul.is_alive():
+            time.sleep(0.001)
+
+        scp.step()
         scp.shutdown()
 
         assert [

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -403,7 +403,11 @@ class TestStateBase:
 
     def wait_on_state(self, fsm, state, timeout=2):
         start = 0
-        while fsm.current_state != state and start < timeout:
+        while (
+            fsm.current_state != state
+            and fsm.current_state not in state
+            and start < timeout
+        ):
             time.sleep(0.0001)
             start += 0.0001
 
@@ -1436,6 +1440,7 @@ class TestState03(TestStateBase):
 
         assoc.acse._negotiate_as_acceptor = _neg_as_acc
         self.move_to_state(assoc, scp)
+        self.wait_on_state(assoc.dul.state_machine, ["Sta13", "Sta1"])
 
         scp.step()
         scp.shutdown()

--- a/pynetdicom/tests/test_transport.py
+++ b/pynetdicom/tests/test_transport.py
@@ -21,11 +21,13 @@ from pynetdicom import AE, evt, _config, debug_logger
 from pynetdicom.association import Association
 from pynetdicom.events import Event
 from pynetdicom._globals import MODE_REQUESTOR
+from pynetdicom.pdu_primitives import A_ASSOCIATE
 from pynetdicom import transport
 from pynetdicom.transport import (
     AssociationSocket,
     AssociationServer,
     ThreadedAssociationServer,
+    T_CONNECT,
 )
 from pynetdicom.sop_class import Verification, RTImageStorage
 from .encoded_pdu_items import p_data_tf_rq
@@ -52,6 +54,35 @@ DATASET = dcmread(os.path.join(DCM_DIR, "RTImageStorage.dcm"))
 
 
 # debug_logger()
+
+
+class TestTConnect:
+    """Tests for T_CONNECT."""
+
+    def test_bad_addr_raises(self):
+        """Test a bad init parameter raises exception"""
+        msg = (
+            r"'address' must be 'Tuple\[str, int\]' or "
+            r"'pynetdicom.pdu_primitives.A_ASSOCIATE', not 'NoneType'"
+        )
+        with pytest.raises(TypeError, match=msg):
+            T_CONNECT(None)
+
+    def test_address_tuple(self):
+        """Test init with a tuple"""
+        conn = T_CONNECT(("123", 12))
+        assert conn.address == ("123", 12)
+        assert conn.request is None
+        assert conn.result == ""
+
+    def test_address_request(self):
+        """Test init with an A-ASSOCIATE primitive"""
+        request = A_ASSOCIATE()
+        request.called_presentation_address = ("123", 12)
+        conn = T_CONNECT(request)
+        assert conn.address == ("123", 12)
+        assert conn.request is request
+        assert conn.result == ""
 
 
 class TestAssociationSocket:
@@ -128,7 +159,7 @@ class TestAssociationSocket:
         sock.close()
         assert sock.socket is None
         # Tries to connect, sets to None if fails
-        sock.connect(("", 11112))
+        sock.connect(T_CONNECT(("", 11112)))
         assert sock.event_queue.get() == "Evt17"
         assert sock.socket is None
 

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -301,13 +301,16 @@ class AssociationSocket:
 
     @property
     def event_queue(self) -> "queue.Queue[str]":
-        """Return the :class:`~pynetdicom.association.Association`'s event
+        """Return the :class:`~pynetdicom.association.Association`'s service event
         queue.
         """
         return self.assoc.dul.event_queue
 
     @property
-    def provider_queue(self) -> _QueueType:
+    def provider_queue(self) -> "_QueueType":
+        """Return the :class:`~pynetdicom.association.Association`'s service provider
+        queue.
+        """
         return self.assoc.dul.to_provider_queue
 
     def get_local_addr(self, host: Tuple[str, int] = ("10.255.255.255", 1)) -> str:

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -37,14 +37,57 @@ from pynetdicom._handlers import (
     standard_pdu_recv_handler,
     standard_pdu_sent_handler,
 )
+from pynetdicom.pdu_primitives import A_ASSOCIATE
 from pynetdicom.presentation import PresentationContext
 
 if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.ae import ApplicationEntity
     from pynetdicom.association import Association
+    from pynetdicom.dul import _QueueType
 
 
 LOGGER = logging.getLogger("pynetdicom.transport")
+
+
+class T_CONNECT:
+    """A TRANSPORT CONNECTION primitive
+
+    .. versionadded:: 2.0
+    """
+
+    def __init__(self, address: Union[Tuple[str, int], "A_ASSOCIATE"]) -> None:
+        """Create a new TRANSPORT CONNECT primitive.
+
+        Parameters
+        ----------
+        address : Union[Tuple[str, int], pynetdicom.pdu_primitives.A_ASSOCIATE]
+            The ``(str: IP address, int: port)`` or A-ASSOCIATE (request) primitive to
+            use when making a connection with a peer.
+        """
+        self._request = None
+        self.result = ""
+
+        if isinstance(address, tuple):
+            self._address = address
+        elif isinstance(address, A_ASSOCIATE):
+            self._address = cast(Tuple[str, int], address.called_presentation_address)
+            self._request = address
+        else:
+            raise TypeError(
+                f"'address' must be 'Tuple[str, int]' or "
+                "'pynetdicom.pdu_primitives.A_ASSOCIATE', not "
+                f"'{address.__class__.__name__}'"
+            )
+
+    @property
+    def address(self) -> Tuple[str, int]:
+        """Return the peer's ``(str: IP address, int: port)``."""
+        return self._address
+
+    @property
+    def request(self) -> Optional[A_ASSOCIATE]:
+        """Return the A-ASSOCIATE (request) primitive, or ``None`` if not available."""
+        return self._request
 
 
 class AssociationSocket:
@@ -147,18 +190,18 @@ class AssociationSocket:
         # Evt17: Transport connection closed
         self.event_queue.put("Evt17")
 
-    def connect(self, address: Tuple[str, int]) -> None:
+    def connect(self, primitive: T_CONNECT) -> None:
         """Try and connect to a remote at `address`.
 
-        **Events Emitted**
+        .. versionchanged:: 2.0
 
-        - Evt2: Transport connection confirmed
-        - Evt17: Transport connection closed
+            Changed to take a :class:`~pynetdicom.transport.T_CONNECT` primitive rather
+            than an address tuple.
 
         Parameters
         ----------
-        address : 2-tuple
-            The ``(host: str, port: int)`` IPv4 address to connect to.
+        primitive : pynetdicom.transport.T_CONNECT
+            The TRANSPORT CONNECT primitive to use when connecting to a peer.
         """
         if self.socket is None:
             self.socket = self._create_socket()
@@ -178,14 +221,15 @@ class AssociationSocket:
             self.socket.settimeout(self.assoc.connection_timeout)
             # Try and connect to remote at (address, port)
             #   raises socket.error if connection refused
-            self.socket.connect(address)
+            self.socket.connect(primitive.address)
             # Clear ae connection timeout
             self.socket.settimeout(None)
             # Trigger event - connection open
-            evt.trigger(self.assoc, evt.EVT_CONN_OPEN, {"address": address})
+            evt.trigger(self.assoc, evt.EVT_CONN_OPEN, {"address": primitive.address})
             self._is_connected = True
             # Evt2: Transport connection confirmation
-            self.event_queue.put("Evt2")
+            primitive.result = "Evt2"
+            self.provider_queue.put(primitive)
         except OSError as exc:
             # Log connection failure
             LOGGER.error("Association request failed: unable to connect to remote")
@@ -203,7 +247,9 @@ class AssociationSocket:
                     pass
                 self.socket.close()
                 self.socket = None
-            self.event_queue.put("Evt17")
+
+            primitive.result = "Evt17"
+            self.provider_queue.put(primitive)
         finally:
             self._ready.set()
 
@@ -259,6 +305,10 @@ class AssociationSocket:
         queue.
         """
         return self.assoc.dul.event_queue
+
+    @property
+    def provider_queue(self) -> _QueueType:
+        return self.assoc.dul.to_provider_queue
 
     def get_local_addr(self, host: Tuple[str, int] = ("10.255.255.255", 1)) -> str:
         """Return an address for the local computer as :class:`str`.

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -56,7 +56,7 @@ class T_CONNECT:
     """
 
     def __init__(self, address: Union[Tuple[str, int], "A_ASSOCIATE"]) -> None:
-        """Create a new TRANSPORT CONNECT primitive.
+        """Create a new TRANSPORT CONNECTION primitive.
 
         Parameters
         ----------
@@ -306,13 +306,6 @@ class AssociationSocket:
         """
         return self.assoc.dul.event_queue
 
-    @property
-    def provider_queue(self) -> "_QueueType":
-        """Return the :class:`~pynetdicom.association.Association`'s service provider
-        queue.
-        """
-        return self.assoc.dul.to_provider_queue
-
     def get_local_addr(self, host: Tuple[str, int] = ("10.255.255.255", 1)) -> str:
         """Return an address for the local computer as :class:`str`.
 
@@ -332,6 +325,13 @@ class AssociationSocket:
                 addr = "127.0.0.1"
 
         return addr
+
+    @property
+    def provider_queue(self) -> "_QueueType":
+        """Return the :class:`~pynetdicom.association.Association`'s service provider
+        queue.
+        """
+        return self.assoc.dul.to_provider_queue
 
     @property
     def ready(self) -> bool:


### PR DESCRIPTION
#### Reference issue
* Closes #721
* Added `transport.T_CONNECT`
* `AssociationSocket.connect()` now takes a `T_CONNECT` primitive instead of an address tuple
* Removes `DULServiceProvider.primitive` and `DULServiceProvider.pdu`
* Improves FSM unit test reliability and efficiency

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
