### PR TITLE
[MRG] Allow A-RELEASE instead of A-ABORT on network timeout

### DIFF
--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -81,6 +81,10 @@ Enhancements
 
 * The DUL reactor should be more performant when processing multiple successive events
   (:pr:`651`)
+* Added `Association.network_timeout_response
+  <pynetdicom.association.Association.network_timeout_response>` to allow normal
+  association release on network timeout expiry rather than an abort (:issue:`619`)
+
 
 
 Changes

--- a/docs/changelog/v2.0.0.rst
+++ b/docs/changelog/v2.0.0.rst
@@ -81,7 +81,7 @@ Enhancements
 
 * The DUL reactor should be more performant when processing multiple successive events
   (:pr:`651`)
-* Added `Association.network_timeout_response
+* Added :attr:`Association.network_timeout_response
   <pynetdicom.association.Association.network_timeout_response>` to allow normal
   association release on network timeout expiry rather than an abort (:issue:`619`)
 

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -282,7 +282,7 @@ class DULServiceProvider(Thread):
             pdu_type, _, pdu_length = struct.unpack(">BBL", bytestream)
         except struct.error as exc:
             # READ_PDU_EXC_B
-            LOGGER.error("Insufficient data received to decode the PDU")
+            # LOGGER.error("Insufficient data received to decode the PDU")
             # Evt17: Transport connection closed
             self.event_queue.put("Evt17")
             return

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -3,7 +3,7 @@ The DUL's finite state machine representation.
 """
 import logging
 import queue
-from typing import TYPE_CHECKING, cast, Tuple
+from typing import TYPE_CHECKING, cast
 
 from pynetdicom import evt
 from pynetdicom.pdu import (

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -584,6 +584,7 @@ class TestAssociation:
 
     def test_unknown_abort_source(self, caplog):
         """Test an unknown abort source handled correctly #561"""
+
         def handle_req(event):
             pdu = b"\x07\x00\x00\x00\x00\x04\x00\x00\x01\x00"
             event.assoc.dul.socket.send(pdu)


### PR DESCRIPTION
#### Reference issue
* Closes #619 
* Add `Association.network_timeout_response` to allow A-RELEASE instead of A-BORT

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
