### PR TITLE
[MRG] Stop testing reserved A-ASSOCIATE-AC values

### DIFF
--- a/docs/changelog/v2.1.0.rst
+++ b/docs/changelog/v2.1.0.rst
@@ -6,6 +6,8 @@
 Fixes
 .....
 
+* Fixed reserved A-ASSOCIATE-AC parameters being tested (:issue:`746`)
+
 Enhancements
 ............
 

--- a/pynetdicom/_config.py
+++ b/pynetdicom/_config.py
@@ -298,7 +298,9 @@ Examples
 Perform no validation of **AE** DIMSE elements and AE title PDU parameters:
 
 >>> from pynetdicom import _config
->>> _config.VALIDATORS['AE'] = def my_validator(value): return (True, "")
+>>> def my_validator(value): return (True, "")
+...
+>>> _config.VALIDATORS['AE'] = my_validator
 """
 
 

--- a/pynetdicom/pdu.py
+++ b/pynetdicom/pdu.py
@@ -275,31 +275,30 @@ class PDU:
     def _wrap_encode_str(value: str, pad: int = 0) -> bytes:
         """Return `value` as ASCII encoded :class:`bytes`.
 
-         Each component of Application Context, Abstract Syntax and Transfer
-         Syntax UIDs should be encoded as a ISO 646:1990-Basic G0 Set Numeric
-         String (characters 0-9), with each component separated by '.' (0x2e)
-        .
+        Each component of Application Context, Abstract Syntax and Transfer
+        Syntax UIDs should be encoded as a ISO 646:1990-Basic G0 Set Numeric
+        String (characters 0-9), with each component separated by '.' (0x2e).
 
-         'ascii' is chosen because this is the codec Python uses for ISO 646
-         [3]_.
+        'ascii' is chosen because this is the `codec Python uses
+        <https://docs.python.org/3/library/codecs.html>`_ for ISO 646.
 
-         Parameters
-         ----------
-         value : str
-             The ASCII string to be encoded.
-         pad : int, optional
-             The amount of trailing padding to be used (default ``0``).
+        Parameters
+        ----------
+        value : str
+            The ASCII string to be encoded.
+        pad : int, optional
+            The maximum amount of trailing padding to be used (default ``0``).
 
-         Returns
-         -------
-         bytes
-             The encoded `value`.
+        Returns
+        -------
+        bytes
+            The encoded `value`.
 
-         References
-         ----------
-         * DICOM Standard, Part 8, :dcm:`Annex F <part08/chapter_F.html>`
-         * `Python 3 codecs module
-           <https://docs.python.org/2/library/codecs.html#standard-encodings>`_
+        References
+        ----------
+        * DICOM Standard, Part 8, :dcm:`Annex F <part08/chapter_F.html>`
+        * `Python codecs module
+           <https://docs.python.org/3/library/codecs.html>`_
         """
         return value.ljust(pad).encode("ascii", errors="strict")
 
@@ -896,8 +895,8 @@ class A_ASSOCIATE_AC(PDU):
         # The two reserved parameters at byte offsets 11 and 27 shall be set
         #    to called and calling AET byte the value shall not be
         #   tested when received (PS3.8 Table 9-17)
-        primitive.called_ae_title = self.reserved_aet
-        primitive.calling_ae_title = self.reserved_aec
+        primitive._called_ae_title = self.reserved_aet
+        primitive._calling_ae_title = self.reserved_aec
 
         for item in self.variable_items:
             # Add application context

--- a/pynetdicom/tests/test_pdu.py
+++ b/pynetdicom/tests/test_pdu.py
@@ -734,6 +734,24 @@ class TestASSOC_AC:
         assert primitive.presentation_requirements == "Presentation Kernel"
         assert primitive.session_requirements == ""
 
+    def test_to_primitive_bad_reserved_aet(self):
+        """Test conversion with a non-conformant reserved ae title."""
+        pdu = A_ASSOCIATE_AC()
+        pdu.decode(a_associate_ac)
+        aec = (
+            b"\x4c\x57\x50\x41\x43\x53" b"\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00"
+        )
+        pdu.reserved_aec = aec.decode("ascii")
+        pdu.reserved_aet = aec.decode("ascii")
+
+        primitive = pdu.to_primitive()
+        assert primitive.calling_ae_title == (
+            "LWPACS\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00"
+        )
+        assert primitive.called_ae_title == (
+            "LWPACS\x00\x00\x00\x00\x00\x00\x0f\x00\x00\x00\x00"
+        )
+
     def test_from_primitive(self):
         """Check converting PDU to primitive"""
         orig = A_ASSOCIATE_AC()


### PR DESCRIPTION
#### Reference issue
* Related to #746 
* Don't test reserved A-ASSOCIATE-AC values
* Doc fix for `_config.VALIDATORS`

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
