### PR TITLE
[MRG] Fix AttributeError tests for Python 3.11

### DIFF
--- a/pynetdicom/tests/test_assoc_user.py
+++ b/pynetdicom/tests/test_assoc_user.py
@@ -164,7 +164,7 @@ class TestServiceUserAcceptor:
         """Test that assigning mode after init raises exception."""
         user = ServiceUser(self.assoc, mode="acceptor")
         assert user.mode == "acceptor"
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.mode = "requestor"
 
         assert user.mode == "acceptor"
@@ -297,22 +297,22 @@ class TestServiceUserAcceptor:
         with pytest.raises(RuntimeError, match=msg):
             user.implementation_version_name = "1.2.3"
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.asynchronous_operations = (1, 1)
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.role_selection = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.sop_class_common_extended = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.sop_class_extended = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.user_identity = "test"
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.extended_negotiation = []
 
     def test_add_neg_pre(self):
@@ -1477,7 +1477,7 @@ class TestServiceUserRequestor:
         """Test that assigning mode after init raises exception."""
         user = ServiceUser(self.assoc, mode="requestor")
         assert user.mode == "requestor"
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.mode = "acceptor"
 
         assert user.mode == "requestor"
@@ -1601,22 +1601,22 @@ class TestServiceUserRequestor:
         with pytest.raises(RuntimeError, match=msg):
             user.implementation_version_name = "1.2.3"
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.asynchronous_operations = (1, 1)
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.role_selection = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.sop_class_common_extended = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.sop_class_extended = {}
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.user_identity = "test"
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             user.extended_negotiation = []
 
     def test_accepted_common_raises(self):

--- a/pynetdicom/tests/test_presentation.py
+++ b/pynetdicom/tests/test_presentation.py
@@ -374,7 +374,7 @@ class TestPresentationContext:
         context = build_context("1.2.3")
         assert context.as_scp is None
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             context.as_scp = True
 
         context._as_scp = True
@@ -387,7 +387,7 @@ class TestPresentationContext:
         context = build_context("1.2.3")
         assert context.as_scu is None
 
-        with pytest.raises(AttributeError, match=r"can't set attribute"):
+        with pytest.raises(AttributeError, match=r"can't set attribute|has no setter"):
             context.as_scu = True
 
         context._as_scu = True


### PR DESCRIPTION
In Python 3.11, the messages associated with some `AttributeErrors` have changed. Adjust the message patterns in affected tests to accommodate both new and old message styles.

See #753 for details.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
Fixes #753.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working **Not applicable: existing tests were failing on Python 3.11, and adding a Python 3.11 pre-release to CI is out of scope for me.**
- [x] Fix or feature added **Test fix only; no change to installed library**
- [ ] Documentation and examples updated (if relevant) **Not needed, I think.**
- [ ] Unit tests passing and coverage at 100% after adding fix/feature **Waiting for CI run; should be as good as it was before!**
- [ ] Type annotations updated and passing with mypy **No types changed**
- [ ] Apps updated and tested (if relevant) **Not relevant**
