### PR TITLE
[MRG] Make decoding error tests endian-independent

### DIFF
--- a/pynetdicom/tests/test_utils.py
+++ b/pynetdicom/tests/test_utils.py
@@ -1,5 +1,6 @@
 """Unit tests for the pynetdicom.utils module."""
 
+from codecs import BOM_UTF32_LE
 from io import BytesIO
 from threading import Thread
 import logging
@@ -230,7 +231,7 @@ class TestSetUID:
 
     def test_bytes_decoding_error(self, caplog):
         """Test invalid bytes raises exception"""
-        b = "1.2.3".encode("utf_32")
+        b = BOM_UTF32_LE + "1.2.3".encode("utf_32_le")
         assert isinstance(b, bytes)
         msg = (
             r"Unable to decode 'FF FE 00 00 31 00 00 00 2E 00 00 00 32 00 00 "
@@ -312,7 +313,7 @@ class TestDecodeBytes:
 
     def test_decoding_error(self, caplog):
         """Test decoding error raises and logs"""
-        b = "1.2.3".encode("utf_32")
+        b = BOM_UTF32_LE + "1.2.3".encode("utf_32_le")
         with caplog.at_level(logging.ERROR, logger="pynetdicom"):
             msg = (
                 r"Unable to decode 'FF FE 00 00 31 00 00 00 2E 00 00 00 32 "
@@ -325,7 +326,7 @@ class TestDecodeBytes:
 
     def test_decoding_error_fallback(self, caplog, utf8):
         """Test decoding error raises and logs"""
-        b = "1.2.3".encode("utf_32")
+        b = BOM_UTF32_LE + "1.2.3".encode("utf_32_le")
         with caplog.at_level(logging.ERROR, logger="pynetdicom"):
             msg = (
                 r"Unable to decode 'FF FE 00 00 31 00 00 00 2E 00 00 00 32 "


### PR DESCRIPTION
Fixes #755, test failures on `s390x`.

The test byte string on little-endian hosts is the same as it was before this commit: `b'\xff\xfe\x00\x001\x00\x00\x00.\x00\x00\x002\x00\x00\x00.\x00\x00\x003\x00\x00\x00'`.

On big-endian hosts, the test byte string now matches the one used on little-endian hosts, which makes the nature and message of the exception being tested endianness-independent.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue

Fixes #755.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working **Not applicable: resolves a failure of existing tests on a platform not in CI**
- [x] Fix or feature added **Test fix only; no change to installed library**
- [ ] Documentation and examples updated (if relevant) **Not needed, I think.**
- [ ] Unit tests passing and coverage at 100% after adding fix/feature **Waiting for CI run; should be as good as it was before!**
- [ ] Type annotations updated and passing with mypy **No types changed**
- [ ] Apps updated and tested (if relevant) **Not relevant**
