### PR TITLE
[MRG] Set correct max length for PatientID attribute in qrscp

### DIFF
--- a/docs/changelog/v2.1.0.rst
+++ b/docs/changelog/v2.1.0.rst
@@ -9,6 +9,7 @@ Fixes
 * Fixed reserved A-ASSOCIATE-AC parameters being tested (:issue:`746`)
 * Fixed datasets not transferring correctly when using
   :attr:`~pynetdicom._config.STORE_RECV_CHUNKED_DATASET` (:issue:`756`)
+* Fixed maximum length of PatientID attribute in qrscp app (:issue:`785`)
 
 Enhancements
 ............

--- a/pynetdicom/apps/qrscp/db.py
+++ b/pynetdicom/apps/qrscp/db.py
@@ -174,7 +174,7 @@ def add_instance(ds, session, fpath=None):
     # Unique or Required attributes
     required = [
         # (Instance attribute, DICOM keyword, max length, req'd)
-        ("patient_id", "PatientID", 16, True),
+        ("patient_id", "PatientID", 64, True),
         ("patient_name", "PatientName", 64, False),
         ("study_instance_uid", "StudyInstanceUID", 64, True),
         ("study_date", "StudyDate", 8, False),
@@ -783,7 +783,7 @@ class Instance(Base):
 class Patient(Base):
     __tablename__ = "patient"
     # (0010,0020) Patient ID | VR LO, VM 1, U
-    patient_id = Column(String(16), primary_key=True)
+    patient_id = Column(String(64), primary_key=True)
     # (0010,0010) Patient's Name | VR PN, VM 1, R
     patient_name = Column(String(400))
 

--- a/pynetdicom/apps/tests/test_qrscp_db.py
+++ b/pynetdicom/apps/tests/test_qrscp_db.py
@@ -231,7 +231,7 @@ class TestAddInstance:
     def test_bad_instance(self):
         """Test that instances with bad data aren't added."""
         keywords = [
-            ("PatientID", 16),
+            ("PatientID", 64),
             ("PatientName", 400),
             ("StudyInstanceUID", 64),
             ("StudyDate", 8),
@@ -255,7 +255,7 @@ class TestAddInstance:
     def test_bad_instance_none(self):
         """Test that instances with bad data aren't added."""
         keywords = [
-            ("PatientID", 16),
+            ("PatientID", 64),
             ("PatientName", 64),
             ("StudyInstanceUID", 64),
             ("StudyDate", 8),


### PR DESCRIPTION
Small change in qrscp app (and related tests) to update the maximum length of `PatientID`.

#### Reference issue
#785 

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working _(existing unit tests corrected)_
- [x] Fix or feature added
- [ ] ~~Documentation and examples updated (if relevant)~~ _(don't think it's relevant)_
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] ~~Type annotations updated and passing with mypy~~ _(not relevant)_
- [x] Apps updated and tested (if relevant)
