### PR TITLE
added support for halcyon RT Plan files

### DIFF
--- a/pynetdicom/apps/common.py
+++ b/pynetdicom/apps/common.py
@@ -663,6 +663,7 @@ SOP_CLASS_PREFIXES = {
     "1.2.840.10008.5.1.4.1.1.481.1": ("RI", "RT Image Storage"),
     "1.2.840.10008.5.1.4.1.1.481.2": ("RD", "RT Dose Storage"),
     "1.2.840.10008.5.1.4.1.1.481.5": ("RP", "RT Plan Storage"),
+    "1.2.246.352.70.1.70": ("RP", "Halcyon Plan Storage"),
     "1.2.840.10008.5.1.4.1.1.481.3": ("RS", "RT Structure Set Storage"),
     "1.2.840.10008.5.1.4.1.1.1": ("CR", "Computed Radiography Image Storage"),
     "1.2.840.10008.5.1.4.1.1.6.1": ("US", "Ultrasound Image Storage"),

--- a/pynetdicom/sop_class.py
+++ b/pynetdicom/sop_class.py
@@ -391,6 +391,7 @@ _STORAGE_CLASSES = {
     "RTStructureSetStorage": "1.2.840.10008.5.1.4.1.1.481.3",  # A.19
     "RTBeamsTreatmentRecordStorage": "1.2.840.10008.5.1.4.1.1.481.4",  # A.29
     "RTPlanStorage": "1.2.840.10008.5.1.4.1.1.481.5",  # A.20
+    "HalcyonPlanStorage": "1.2.246.352.70.1.70",
     "RTBrachyTreatmentRecordStorage": "1.2.840.10008.5.1.4.1.1.481.6",  # A.20
     "RTTreatmentSummaryRecordStorage": "1.2.840.10008.5.1.4.1.1.481.7",  # A.31
     "RTIonPlanStorage": "1.2.840.10008.5.1.4.1.1.481.8",  # A.49


### PR DESCRIPTION
#### Reference issue
The issue describing the bug or feature that this PR addresses.
This was performed to add support for halcyon RT Plans, which have an SOP Class UID of 1.2.246.352.70.1.70 #799
#### Tasks
- [ ] Fix or feature added: Can query and use CStore for Halcyon RT Plans requested by an SCP
