### PR TITLE
[MRG] Fix ext link doc formatting, sphinx obsolescence 

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,8 +98,8 @@ extlinks = {
     # Usage :dcm:`link text <part05/sect_6.2.html>`
     "dcm": ("http://dicom.nema.org/medical/dicom/current/output/chtml/%s", None),
     "gh": ("https://github.com/pydicom/%s", None),
-    "issue": ("https://github.com/pydicom/pynetdicom/issues/%s", "#"),
-    "pr": ("https://github.com/pydicom/pynetdicom/pull/%s", "#"),
+    "issue": ("https://github.com/pydicom/pynetdicom/issues/%s", "#%s"),
+    "pr": ("https://github.com/pydicom/pynetdicom/pull/%s", "#%s"),
 }
 
 # intersphinx configuration


### PR DESCRIPTION
update caption to specify "#%s" rather than "#". The latter worked in Sphinx 5.3.0, warned in 6.x, fails in 7.x
This is a bare minimum PR.
Sphinx and sphinx-rtd-theme have a very delicate interplay in terms of versioning (otherwise there is a "style" error), so it's very important that those be updated in compatible fashion (hence using poetry and pyproject.toml... which is not included in this PR so that at least docs will build correctly in CircleCI and we can separate the two topics)
<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
#839 
#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [x] Apps updated and tested (if relevant)
