### PR TITLE
[MRG] eliminate direct source code access to pydicom for typing information…

### DIFF
--- a/.github/workflows/merge-typing.yml
+++ b/.github/workflows/merge-typing.yml
@@ -25,11 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install mypy
-        git clone https://github.com/pydicom/pydicom
         pip install pydicom
-    - name: Enable typing with pydicom
-      run: |
-        touch pydicom/pydicom/py.typed
     - name: Run typing check with mypy
       run: |
         mypy

--- a/.github/workflows/pr-typing.yml
+++ b/.github/workflows/pr-typing.yml
@@ -25,11 +25,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install mypy
-        git clone https://github.com/pydicom/pydicom
         pip install pydicom
-    - name: Enable typing with pydicom
-      run: |
-        touch pydicom/pydicom/py.typed
     - name: Run typing check with mypy
       run: |
         mypy


### PR DESCRIPTION
… and rely on it's packaging that has the typed already available

this avoids a file access error during github workflow action

one of the minimal PRs extracted from the "tidy-up" PR.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
#839 
#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [x] Apps updated and tested (if relevant)
