### PR TITLE
Python3.12: Fix AttributeError

### DIFF
--- a/pynetdicom/tests/hide_modules.py
+++ b/pynetdicom/tests/hide_modules.py
@@ -29,8 +29,12 @@ https://github.com/roryyorke/py-hide-modules
 try:
     import importlib.abc
 
-    # py>=3.3 has MetaPathFinder
-    _ModuleHiderBase = getattr(importlib.abc, "MetaPathFinder", importlib.abc.Finder)
+    try:
+        # py>=3.3 has MetaPathFinder
+        _ModuleHiderBase = getattr(importlib.abc, "MetaPathFinder", importlib.abc.Finder)
+    except AttributeError:
+        # py>=3.12 throws AttributeError using getattr
+        _ModuleHiderBase = importlib.abc.MetaPathFinder
 except ImportError:
     # py2
     _ModuleHiderBase = object


### PR DESCRIPTION
`getattr(importlib.abc, "MetaPathFinder", importlib.abc.Finder)`
throws AttributeError in Python3.12.
