### PR TITLE
[MRG] Replace deprecated aliases of exceptions

### DIFF
--- a/pynetdicom/apps/common.py
+++ b/pynetdicom/apps/common.py
@@ -618,7 +618,7 @@ def handle_store(event, args, app_logger):
             app_logger.error("Unable to create the output directory:")
             app_logger.error(f"    {args.output_directory}")
             app_logger.exception(exc)
-            # Failed - Out of Resources - IOError
+            # Failed - Out of Resources - OSError
             status_ds.Status = 0xA700
             return status_ds
 
@@ -639,11 +639,11 @@ def handle_store(event, args, app_logger):
             ds.save_as(filename, write_like_original=False)
 
         status_ds.Status = 0x0000  # Success
-    except IOError as exc:
+    except OSError as exc:
         app_logger.error("Could not write file to specified directory:")
         app_logger.error(f"    {os.path.dirname(filename)}")
         app_logger.exception(exc)
-        # Failed - Out of Resources - IOError
+        # Failed - Out of Resources - OSError
         status_ds.Status = 0xA700
     except Exception as exc:
         app_logger.error("Could not write file to specified directory:")

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -267,7 +267,7 @@ class DULServiceProvider(Thread):
         # Try and read the PDU type and length from the socket
         try:
             bytestream.extend(self.socket.recv(6))
-        except (socket.error, socket.timeout) as exc:
+        except (OSError, TimeoutError) as exc:
             # READ_PDU_EXC_A
             LOGGER.error("Connection closed before the entire PDU was received")
             LOGGER.exception(exc)
@@ -298,7 +298,7 @@ class DULServiceProvider(Thread):
         # Try and read the rest of the PDU
         try:
             bytestream += self.socket.recv(pdu_length)
-        except (socket.error, socket.timeout) as exc:
+        except (OSError, TimeoutError) as exc:
             # READ_PDU_EXC_D
             LOGGER.error("Connection closed before the entire PDU was received")
             LOGGER.exception(exc)

--- a/pynetdicom/tests/parrot.py
+++ b/pynetdicom/tests/parrot.py
@@ -61,7 +61,7 @@ class ParrotRequest(BaseRequestHandler):
         try:
             # Use a timeout of 0 so we get an "instant" result
             ready, _, _ = select.select([self.socket], [], [], 0.5)
-        except (socket.error, socket.timeout, ValueError):
+        except (OSError, TimeoutError, ValueError):
             return False
 
         return bool(ready)
@@ -73,7 +73,7 @@ class ParrotRequest(BaseRequestHandler):
         # Try and read the PDU type and length from the socket
         try:
             bytestream.extend(self.recv(6))
-        except (socket.error, socket.timeout):
+        except (OSError, TimeoutError):
             pass
         try:
             # Byte 1 is always the PDU type
@@ -86,7 +86,7 @@ class ParrotRequest(BaseRequestHandler):
         # Try and read the rest of the PDU
         try:
             bytestream += self.recv(pdu_length)
-        except (socket.error, socket.timeout):
+        except (OSError, TimeoutError):
             pass
 
         return bytestream
@@ -154,7 +154,7 @@ class ParrotRequest(BaseRequestHandler):
                 # Returns the number of bytes sent
                 nr_sent = self.socket.send(bytestream)
                 total_sent += nr_sent
-        except (socket.error, socket.timeout):
+        except (OSError, TimeoutError):
             # Evt17: Transport connection closed
             return False
 

--- a/pynetdicom/tests/test_fsm.py
+++ b/pynetdicom/tests/test_fsm.py
@@ -1846,7 +1846,7 @@ class TestState04(TestStateBase):
             try:
                 assoc.dul.socket.socket.connect(address)
                 assoc.dul.socket._is_connected = True
-            except (socket.error, socket.timeout) as exc:
+            except (OSError, TimeoutError) as exc:
                 assoc.dul.socket.close()
 
         assoc.dul.socket.connect = connect

--- a/pynetdicom/tests/test_transport.py
+++ b/pynetdicom/tests/test_transport.py
@@ -778,7 +778,7 @@ class TestAssociationServer:
         server.shutdown()
 
         if sys.version_info[0] == 2:
-            with pytest.raises(socket.error):
+            with pytest.raises(OSError):
                 server.socket.fileno()
         else:
             assert server.socket.fileno() == -1

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -199,7 +199,7 @@ class AssociationSocket:
 
         try:
             self.socket.shutdown(socket.SHUT_RDWR)
-        except socket.error:
+        except OSError:
             pass
 
         self.socket.close()
@@ -238,7 +238,7 @@ class AssociationSocket:
             # Set ae connection timeout
             self.socket.settimeout(self.assoc.connection_timeout)
             # Try and connect to remote at (address, port)
-            #   raises socket.error if connection refused
+            #   raises OSError if connection refused
             self.socket.connect(primitive.address)
             # Clear ae connection timeout
             self.socket.settimeout(None)
@@ -363,7 +363,7 @@ class AssociationSocket:
         try:
             # Use a timeout of 0 so we get an "instant" result
             ready, _, _ = select.select([self.socket], [], [], 0)
-        except (socket.error, socket.timeout, ValueError):
+        except (OSError, TimeoutError, ValueError):
             # Evt17: Transport connection closed
             self.event_queue.put("Evt17")
             return False
@@ -442,7 +442,7 @@ class AssociationSocket:
                 total_sent += nr_sent
 
             evt.trigger(self.assoc, evt.EVT_DATA_SENT, {"data": bytestream})
-        except (socket.error, socket.timeout):
+        except (OSError, TimeoutError):
             # Evt17: Transport connection closed
             self.event_queue.put("Evt17")
 
@@ -816,7 +816,7 @@ class AssociationServer(TCPServer):
         self.socket = cast(socket.socket, self.socket)
         try:
             self.socket.shutdown(socket.SHUT_RDWR)
-        except socket.error:
+        except OSError:
             pass
 
         self.socket.close()


### PR DESCRIPTION
* [`IOError` → `OSError`](https://docs.python.org/3/library/exceptions.html#IOError)
* [`socket.error` → `OSError`](https://docs.python.org/3/library/socket.html#socket.error)
* [`socket.timeout` → `TimeoutError`](https://docs.python.org/3/library/socket.html#socket.timeout)

<!--* [`IOError` → `OSError`](https://docs.python.org/3/library/exceptions.html#IOError)
* [`socket.error` → `OSError`](https://docs.python.org/3/library/socket.html#socket.error)
* [`socket.timeout` → `TimeoutError`](https://docs.python.org/3/library/socket.html#socket.timeout)

Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Type annotations updated and passing with mypy
- [ ] Apps updated and tested (if relevant)
