### PR TITLE
[MRG] `{str(x)}` → `{x}`

### DIFF
--- a/pynetdicom/service_class.py
+++ b/pynetdicom/service_class.py
@@ -289,7 +289,7 @@ class ServiceClass:
                 LOGGER.error(
                     "\nTraceback (most recent call last):\n"
                     + "".join(traceback.format_tb(exc[2]))
-                    + f"{exc[0].__name__}: {str(exc[1])}"  # type: ignore
+                    + f"{exc[0].__name__}: {exc[1]}"  # type: ignore
                 )
                 rsp_status = 0xC311
                 dataset = None
@@ -1707,7 +1707,7 @@ class QueryRetrieveServiceClass(ServiceClass):
                 LOGGER.error(
                     "\nTraceback (most recent call last):\n"
                     + "".join(traceback.format_tb(exc[2]))
-                    + f"{exc[0].__name__}: {str(exc[1])}"  # type: ignore
+                    + f"{exc[0].__name__}: {exc[1]}"  # type: ignore
                 )
                 rsp_status = 0xC411
                 dataset = None
@@ -2131,7 +2131,7 @@ class QueryRetrieveServiceClass(ServiceClass):
                 LOGGER.error(
                     "\nTraceback (most recent call last):\n"
                     + "".join(traceback.format_tb(exc[2]))
-                    + f"{exc[0].__name__}: {str(exc[1])}"  # type: ignore
+                    + f"{exc[0].__name__}: {exc[1]}"  # type: ignore
                 )
                 rsp_status = 0xC511
                 dataset = None


### PR DESCRIPTION
Casting to `str` is redundant, it is the default.

From [Format Specification Mini-Language](https://docs.python.org/3/library/string.html#format-specification-mini-language):
> A general convention is that an empty format specification produces the same result as if you had called [`str()`](https://docs.python.org/3/library/stdtypes.html#str) on the value. A non-empty format specification typically modifies the result.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Type annotations updated and passing with mypy
- [ ] Apps updated and tested (if relevant)
