### PR TITLE
[MRG] Check for encoding mismatch with send_c_store()

### DIFF
--- a/docs/changelog/v2.1.0.rst
+++ b/docs/changelog/v2.1.0.rst
@@ -13,6 +13,7 @@ Fixes
 * Sanitise filenames for received datasets for non-conformant SOP Instance
   UIDs (:issue:`823`)
 
+
 Enhancements
 ............
 
@@ -27,6 +28,10 @@ Enhancements
   <pynetdicom.service_class.StorageManagementServiceClass>` (:issue:`880`)
 * Added :meth:`~pynetdicom.events.Event.encoded_dataset` to simplify accessing
   the encoded dataset without first decoding it
+* Added a check to :meth:`~pynetdicom.association.Association.send_c_store` to
+  ensure that the *Transfer Syntax UID* matches the encoding of the dataset
+  (:issue:`891`)
+
 
 Changes
 .......

--- a/pynetdicom/ae.py
+++ b/pynetdicom/ae.py
@@ -45,8 +45,8 @@ LOGGER = logging.getLogger("pynetdicom.ae")
 
 
 _T = TypeVar("_T")
-ListCXType = List[PresentationContext]
-TSyntaxType = Optional[Union[str, UID, Sequence[Union[str, UID]]]]
+ListCXType = list[PresentationContext]
+TSyntaxType = None | str | UID | Sequence[str] | Sequence[UID]
 
 
 class ApplicationEntity:

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -1885,17 +1885,15 @@ class Association(threading.Thread):
                 tsyntax.is_implicit_VR,
                 tsyntax.is_little_endian,
             )
-            ds_encoding = cast(
-                tuple[bool, bool],
-                getattr(
-                    dataset,
-                    "original_encoding",
-                    (dataset.is_implicit_VR, dataset.is_little_endian),
-                ),
+            # `dataset` might also be created from scratch
+            ds_encoding = getattr(
+                dataset,
+                "original_encoding",
+                (dataset.is_implicit_VR, dataset.is_little_endian),
             )
-            if ts_encoding != ds_encoding:
-                s = ("explicit VR", "implicit VR")[ds_encoding[0]]
-                s += (" big endian", " little endian")[ds_encoding[1]]
+            if None not in ds_encoding and ts_encoding != ds_encoding:
+                s = ("explicit VR", "implicit VR")[cast(bool, ds_encoding[0])]
+                s += (" big endian", " little endian")[cast(bool, ds_encoding[1])]
                 msg = (
                     f"'dataset' is encoded as {s} but the file meta has a "
                     f"(0002,0010) Transfer Syntax UID of '{tsyntax.name}'"

--- a/pynetdicom/tests/test_assoc.py
+++ b/pynetdicom/tests/test_assoc.py
@@ -1846,6 +1846,69 @@ class TestAssociationSendCStore:
 
         scp.shutdown()
 
+    def test_dataset_encoding_mismatch(self, caplog):
+        """Tests for when transfer syntax doesn't match dataset encoding."""
+
+        def handle_store(event):
+            return 0x0000
+
+        handlers = [(evt.EVT_C_STORE, handle_store)]
+
+        self.ae = ae = AE()
+        ae.acse_timeout = 5
+        ae.dimse_timeout = 5
+        ae.network_timeout = 5
+        ae.add_supported_context(
+            CTImageStorage,
+            [ExplicitVRBigEndian, ImplicitVRLittleEndian],
+        )
+        scp = ae.start_server(("localhost", 11112), block=False, evt_handlers=handlers)
+
+        ae.add_requested_context(CTImageStorage, ImplicitVRLittleEndian)
+        ae.add_requested_context(CTImageStorage, ExplicitVRBigEndian)
+        assoc = ae.associate("localhost", 11112)
+
+        assert assoc.is_established
+        ds = dcmread(DATASET_PATH)
+        assert ds.is_little_endian
+        assert not ds.is_implicit_VR
+        assert ds.file_meta.TransferSyntaxUID == ExplicitVRLittleEndian
+        ds.is_implicit_VR = True
+        with caplog.at_level(logging.WARNING, logger="pynetdicom"):
+            status = assoc.send_c_store(ds)
+            assert status.Status == 0x0000
+
+            ds.is_implicit_VR = False
+            ds.is_little_endian = False
+            status = assoc.send_c_store(ds)
+            assert status.Status == 0x0000
+
+        ds.is_implicit_VR = False
+        ds.is_little_endian = True
+        ds.file_meta.TransferSyntaxUID = ImplicitVRLittleEndian
+        msg = (
+            "'dataset' is encoded as explicit VR little endian but the file "
+            r"meta has a \(0002,0010\) Transfer Syntax UID of 'Implicit VR "
+            "Little Endian' - please set an appropriate Transfer Syntax"
+        )
+        with pytest.raises(AttributeError, match=msg):
+            status = assoc.send_c_store(ds)
+
+        assoc.release()
+        assert assoc.is_released
+        scp.shutdown()
+
+        assert (
+            "'dataset' is encoded as implicit VR little endian but the file "
+            "meta has a (0002,0010) Transfer Syntax UID of 'Explicit VR "
+            "Little Endian' - using 'Implicit VR Little Endian' instead"
+        ) in caplog.text
+        assert (
+            "'dataset' is encoded as explicit VR big endian but the file "
+            "meta has a (0002,0010) Transfer Syntax UID of 'Explicit VR "
+            "Little Endian' - using 'Explicit VR Big Endian' instead"
+        ) in caplog.text
+
     # Regression tests
     def test_no_send_mismatch(self):
         """Test sending a dataset with mismatched transfer syntax (206)."""


### PR DESCRIPTION
#### Reference issue
Check for a mismatch between transfer syntax and dataset encoding and either try to fix it or raise if unable to. Closes #891

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
