### PR TITLE
Remove the overwriting of sys.argv

### DIFF
--- a/pynetdicom/__main__.py
+++ b/pynetdicom/__main__.py
@@ -25,4 +25,4 @@ if __name__ == "__main__":
     else:
         app_path = _APPS[args[0]]
         app = importlib.import_module(app_path)
-        app.main(args)
+        app.main(args[1:])

--- a/pynetdicom/apps/echoscp/echoscp.py
+++ b/pynetdicom/apps/echoscp/echoscp.py
@@ -19,10 +19,11 @@ from pynetdicom.sop_class import Verification
 __version__ = "0.7.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="echoscp",
         description=(
             "The echoscp application implements a Service Class "
             "Provider (SCP) for the Verification SOP Class. It "
@@ -160,7 +161,7 @@ def _setup_argparser():
         action="store_true",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def handle_echo(event):
@@ -173,10 +174,7 @@ def handle_echo(event):
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"echoscp.py v{__version__}")

--- a/pynetdicom/apps/echoscu/echoscu.py
+++ b/pynetdicom/apps/echoscu/echoscu.py
@@ -24,10 +24,11 @@ from pynetdicom.sop_class import Verification
 __version__ = "0.7.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="echoscu",
         description=(
             "The echoscu application implements a Service Class User "
             "(SCU) for the Verification Service Class. It sends a DICOM "
@@ -171,15 +172,12 @@ def _setup_argparser():
         "--abort", help="abort association instead of releasing it", action="store_true"
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"echoscu.py v{__version__}")

--- a/pynetdicom/apps/findscu/findscu.py
+++ b/pynetdicom/apps/findscu/findscu.py
@@ -35,10 +35,11 @@ from pynetdicom.sop_class import (
 __version__ = "0.2.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="findscu",
         description=(
             "The findscu application implements a Service Class User "
             "(SCU) for the Query/Retrieve (QR) and Basic Worklist Management "
@@ -241,7 +242,7 @@ def _setup_argparser():
         action="store_true",
     )
 
-    ns = parser.parse_args()
+    ns = parser.parse_args(args)
     if ns.version:
         pass
     elif not bool(ns.file) and not bool(ns.keyword):
@@ -275,10 +276,7 @@ def generate_filename():
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"findscu.py v{__version__}")

--- a/pynetdicom/apps/getscu/getscu.py
+++ b/pynetdicom/apps/getscu/getscu.py
@@ -29,10 +29,11 @@ from pynetdicom.sop_class import (
 __version__ = "0.4.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="getscu",
         description=(
             "The getscu application implements a Service Class User "
             "(SCU) for the Query/Retrieve (QR) Service Class. getscu only "
@@ -214,7 +215,7 @@ def _setup_argparser():
         "--ignore", help="receive data but don't store it", action="store_true"
     )
 
-    ns = parser.parse_args()
+    ns = parser.parse_args(args)
     if ns.version:
         pass
     elif not bool(ns.file) and not bool(ns.keyword):
@@ -225,10 +226,7 @@ def _setup_argparser():
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"getscu.py v{__version__}")

--- a/pynetdicom/apps/movescu/movescu.py
+++ b/pynetdicom/apps/movescu/movescu.py
@@ -26,10 +26,11 @@ from pynetdicom.sop_class import (
 __version__ = "0.4.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="movescu",
         description=(
             "The movescu application implements a Service Class User (SCU) "
             "for the Query/Retrieve (QR) Service Class and (optionally) a "
@@ -247,7 +248,7 @@ def _setup_argparser():
         "--ignore", help="receive data but don't store it", action="store_true"
     )
 
-    ns = parser.parse_args()
+    ns = parser.parse_args(args)
     if ns.version:
         pass
     elif not bool(ns.file) and not bool(ns.keyword):
@@ -258,10 +259,7 @@ def _setup_argparser():
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"movescu.py v{__version__}")

--- a/pynetdicom/apps/qrscp/qrscp.py
+++ b/pynetdicom/apps/qrscp/qrscp.py
@@ -94,10 +94,11 @@ def _log_config(config, logger):
     logger.debug("")
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="qrscp",
         description=(
             "The qrscp application implements a Service Class Provider (SCP) "
             "for the Verification, Storage and Query/Retrieve (QR) Service "
@@ -218,7 +219,7 @@ def _setup_argparser():
         action="store_true",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def clean(db_path, instance_path, logger):
@@ -289,10 +290,7 @@ def clean(db_path, instance_path, logger):
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"qrscp.py v{__version__}")

--- a/pynetdicom/apps/storescp/storescp.py
+++ b/pynetdicom/apps/storescp/storescp.py
@@ -26,10 +26,11 @@ from pynetdicom._globals import ALL_TRANSFER_SYNTAXES, DEFAULT_MAX_LENGTH
 __version__ = "0.6.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="storescp",
         description=(
             "The storescp application implements a Service Class "
             "Provider (SCP) for the Storage and Verification SOP Classes. It "
@@ -185,15 +186,13 @@ def _setup_argparser():
         "--no-echo", help="don't act as a verification SCP", action="store_true"
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
+    args = _setup_argparser(args)
 
-    args = _setup_argparser()
     if args.version:
         print(f"storescp.py v{__version__}")
         sys.exit()

--- a/pynetdicom/apps/storescu/storescu.py
+++ b/pynetdicom/apps/storescu/storescu.py
@@ -26,10 +26,11 @@ from pynetdicom._globals import DEFAULT_MAX_LENGTH
 __version__ = "0.3.0"
 
 
-def _setup_argparser():
+def _setup_argparser(args=None):
     """Setup the command line arguments"""
     # Description
     parser = argparse.ArgumentParser(
+        prog="storescu",
         description=(
             "The storescu application implements a Service Class User "
             "(SCU) for the Storage Service Class. For each DICOM "
@@ -189,7 +190,7 @@ def _setup_argparser():
         action="store_true",
     )
 
-    return parser.parse_args()
+    return parser.parse_args(args)
 
 
 def get_contexts(fpaths, app_logger):
@@ -238,10 +239,7 @@ def get_contexts(fpaths, app_logger):
 
 def main(args=None):
     """Run the application."""
-    if args is not None:
-        sys.argv = args
-
-    args = _setup_argparser()
+    args = _setup_argparser(args)
 
     if args.version:
         print(f"storescu.py v{__version__}")


### PR DESCRIPTION
There's no need to do this since argparse can accept a list of arguments, and it doesn't seem like a good idea to overwrite the list of arguments provided.

<!--
Please prefix your PR title with [WIP] for PRs that are in
progress and [MRG] when you consider them ready for review.
-->
#### Reference issue
N/A

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [x] Apps updated and tested (if relevant)
