### PR TITLE
Improvements for handling P-DATA received during association release

### DIFF
--- a/docs/changelog/v3.0.0.rst
+++ b/docs/changelog/v3.0.0.rst
@@ -16,6 +16,8 @@ Changes
 * Minimum supported pydicom version is 3.0 (:issue:`981`)
 * Added support for Python 3.13
 * Updated SOP classes to version 2025b of the DICOM Standard
+* P-DATA PDUs received during association release are now added to the normal DIMSE
+  messaging queue
 
 Enhancements
 ------------
@@ -24,3 +26,9 @@ Enhancements
   absent from the N-CREATE-RQ can now be done by adding it to the returned *Attribute
   List* dataset (it'll be removed from the dataset prior to sending) (:issue:`995`)
 * Added debugging handlers for the remaining DIMSE-N messages
+
+
+Fixes
+-----
+* Fixed a state machine error caused by receiving N-EVENT-REPORT requests during
+  association release (:issue:`820`)

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -282,12 +282,9 @@ class ACSE:
             "a-abort": (A_ABORT,),
             "a-p-abort": (A_P_ABORT,),
         }
-
         primitive = self.dul.peek_next_pdu()
-        if isinstance(primitive, abort_classes[abort_type]):
-            return True
 
-        return False
+        return isinstance(primitive, abort_classes[abort_type])
 
     def is_release_requested(self) -> bool:
         """Return ``True`` if an A-RELEASE request has been received.
@@ -598,12 +595,10 @@ class ACSE:
                 return
 
             # Any other primitive besides A_RELEASE gets trashed
-            elif not isinstance(primitive, A_RELEASE):
-                # Should only be P-DATA
-                LOGGER.warning(
-                    "P-DATA received after Association release, data has been lost"
-                )
-                continue
+            # if not isinstance(primitive, A_RELEASE):
+            #     # Should only be P-DATA
+            #     LOGGER.info("P-DATA received during asssociation release, ignoring")
+            #     continue
 
             # Must be A-RELEASE, but may be either request or release
             if primitive.result is None:
@@ -809,6 +804,7 @@ class ACSE:
         if is_response:
             primitive.result = "affirmative"
 
+        self.assoc._sent_release = True
         self.dul.send_pdu(primitive)
 
     def send_request(self) -> None:

--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -594,12 +594,6 @@ class ACSE:
                 self.assoc.kill()
                 return
 
-            # Any other primitive besides A_RELEASE gets trashed
-            # if not isinstance(primitive, A_RELEASE):
-            #     # Should only be P-DATA
-            #     LOGGER.info("P-DATA received during asssociation release, ignoring")
-            #     continue
-
             # Must be A-RELEASE, but may be either request or release
             if primitive.result is None:
                 # A-RELEASE (request) received, therefore an

--- a/pynetdicom/dimse_messages.py
+++ b/pynetdicom/dimse_messages.py
@@ -735,6 +735,11 @@ class DIMSEMessage:
 
         return primitive
 
+    @property
+    def msg_type(self) -> str:
+        """Return the DIMSE message's type, such as C-ECHO-RQ."""
+        return type(self).__name__.replace("_", "-")
+
     def primitive_to_message(self, primitive: DimsePrimitiveType) -> None:
         """Convert a DIMSE `primitive` to the current ``DIMSEMessage`` object.
 

--- a/pynetdicom/dimse_messages.py
+++ b/pynetdicom/dimse_messages.py
@@ -735,11 +735,6 @@ class DIMSEMessage:
 
         return primitive
 
-    @property
-    def msg_type(self) -> str:
-        """Return the DIMSE message's type, such as C-ECHO-RQ."""
-        return type(self).__name__.replace("_", "-")
-
     def primitive_to_message(self, primitive: DimsePrimitiveType) -> None:
         """Convert a DIMSE `primitive` to the current ``DIMSEMessage`` object.
 

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -83,6 +83,8 @@ class DULServiceProvider(Thread):
         #   user and the DUL service provider.
         # An event occurs when the DUL service user adds to
         #   the to_provider_queue
+        # The queue contains A-ASSOCIATE, A-RELEASE, A-ABORT, A-P-ABORT, P-DATA and
+        #   T-CONNECT primitives from the local user that are to be sent to the peer
         self.to_provider_queue: "_QueueType" = queue.Queue()
         # A primitive is sent to the service user when the DUL service provider
         # adds to the to_user_queue.

--- a/pynetdicom/dul.py
+++ b/pynetdicom/dul.py
@@ -195,7 +195,7 @@ class DULServiceProvider(Thread):
     def peek_next_pdu(self) -> "_UserQueuePrimitives | None":
         """Check the next PDU to be processed."""
         try:
-            return cast(_UserQueuePrimitives, self.to_user_queue.queue[0])
+            return cast("_UserQueuePrimitives", self.to_user_queue.queue[0])
         except (queue.Empty, IndexError):
             return None
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -503,7 +503,7 @@ def AR_2(dul: "DULServiceProvider") -> str:
         ``'Sta8'``, the next state of the state machine
     """
     # A-RELEASE-RQ PDU received from peer
-    pdu = dul._recv_pdu.get(False)
+    pdu = cast("A_RELEASE_RQ", dul._recv_pdu.get(False))
 
     # Send A-RELEASE indication primitive
     dul.to_user_queue.put(pdu.to_primitive())
@@ -530,7 +530,7 @@ def AR_3(dul: "DULServiceProvider") -> str:
         ``'Sta1'``, the next state of the state machine
     """
     # A-RELEASE-RP PDU received from peer
-    pdu = dul._recv_pdu.get(False)
+    pdu = cast("A_RELEASE_RP", dul._recv_pdu.get(False))
 
     # Issue A-RELEASE confirmation primitive and close transport connection
     dul.to_user_queue.put(pdu.to_primitive())

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -628,7 +628,7 @@ def AR_6(dul: "DULServiceProvider") -> str:
     pdu = cast("P_DATA_TF", dul._recv_pdu.get(False))
 
     # Issue P-DATA indication
-    dul.to_user_queue.put(pdu.to_primitive())
+    dul.assoc.dimse.receive_primitive(pdu.to_primitive())
 
     return "Sta7"
 
@@ -762,6 +762,7 @@ def AA_1(dul: "DULServiceProvider") -> str:
     """
     # Received invalid PDU from peer or an A-ABORT primitive from local user
     try:
+        # A-ABORT or A-P-ABORT from local user
         primitive = dul.to_provider_queue.queue[0]
         if isinstance(primitive, (A_ABORT, A_P_ABORT)):
             primitive = dul.to_provider_queue.get(False)

--- a/pynetdicom/tests/encoded_pdu_items.py
+++ b/pynetdicom/tests/encoded_pdu_items.py
@@ -433,7 +433,7 @@ a_abort = b"\x07\x00\x00\x00\x00\x04\x00\x00\x00\x00"
 a_p_abort = b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x04"
 
 ################################ P-DATA-TF PDU ###############################
-# Contains a C-ECHO message
+# Contains a C-ECHO-RSP message
 # Context ID: 1
 # Data: \x03\x00\x00\x00\x00\x04\x00\x00\x00\x42\x00\x00\x00\x00\x00\x02\x00
 #       \x12\x00\x00\x00\x31\x2e\x32\x2e\x38\x34\x30\x2e\x31\x30\x30\x30\x38
@@ -453,8 +453,8 @@ a_p_abort = b"\x07\x00\x00\x00\x00\x04\x00\x00\x02\x04"
 #       00 00 02 00 | 12 00 00 00 | 31 2e ... 31 00- Affected SOP Class UID
 #       00 00 00 01 | 02 00 00 00 | 30 80 - Command Field (32816)
 #       00 00 20 01 | 02 00 00 00 | - MessageIDBeingRespondedTo (1)
-#       00 00 00 08 |             | - Command Data Set Type (257)
-#       00 00 00 09 | - Status (0)
+#       00 00 00 08 | 02 00 00 00 | 01 01 - Command Data Set Type (257)
+#       00 00 00 09 | 02 00 00 00 | 00 00 - Status (0)
 p_data_tf = (
     b"\x04\x00\x00\x00\x00\x54\x00\x00\x00\x50\x01\x03\x00\x00\x00"
     b"\x00\x04\x00\x00\x00\x42\x00\x00\x00\x00\x00\x02\x00\x12\x00"
@@ -475,6 +475,31 @@ p_data_tf_rq = (
     b"\x00\x00\x00\x01\x02\x00\x00\x00\x30\x00"  # Command Field
     b"\x00\x00\x10\x01\x02\x00\x00\x00\x01\x00"  # Message ID
     b"\x00\x00\x00\x08\x02\x00\x00\x00\x01\x01"  # Command Data Set Type
+)
+
+# N-EVENT-REPORT RQ - Command Set is implicit little
+p_data_tf_n_event_report = (
+    b"\x04\x00\x00\x00\x00\x76"  # P-DATA: 1 type, 2 reserved, 3-6 length
+    b"\x00\x00\x00\x72\x01"  # 7+: PDV Item(s): 1-4 length, 5, CID, 6+ PDV value
+    b"\x03"  # PDV 1, message control header byte
+    # (0000,0000), Length 4, Value 0x64 0x00 0x00 0x000
+    b"\x00\x00\x00\x00\x04\x00\x00\x00\x64\x00\x00\x00"  # Command Group Length
+    # (0000,0002), Length 0x16
+    b"\x00\x00\x02\x00\x16\x00\x00\x00"  # Affected
+    b"\x31\x2e\x32\x2e\x38\x34\x30\x2e\x31\x30\x30\x30\x38\x2e\x35\x2e"
+    b"\x31\x2e\x31\x2e\x31\x34"
+    # (0000,0100), Length 2,
+    b"\x00\x00\x00\x01\x02\x00\x00\x00\x00\x01"
+    # (0000,0110), Length 2
+    b"\x00\x00\x10\x01\x02\x00\x00\x00\x01\x00"
+    # (0000,0800), Length 2
+    b"\x00\x00\x00\x08\x02\x00\x00\x00\x01\x01"  # 0x0101, no data set
+    # (0000,1000), Length 0x116
+    b"\x00\x00\x00\x10\x16\x00\x00\x00\x31\x2e\x32\x2e"
+    b"\x38\x34\x30\x2e\x31\x30\x30\x30\x38\x2e\x35\x2e\x31\x2e\x31\x2e"
+    b"\x31\x37"
+    # (0000,1002), Length 2
+    b"\x00\x00\x02\x10\x02\x00\x00\x00\x03\x00"
 )
 
 # AsynchronousOperationsWindow

--- a/pynetdicom/tests/parrot.py
+++ b/pynetdicom/tests/parrot.py
@@ -39,12 +39,16 @@ class ParrotRequest(BaseRequestHandler):
                 self.kill_read = False
                 while not self.kill_read:
                     if self.ready:
-                        self.received.append(bytes(self.read_data))
+                        d = bytes(self.read_data)
+                        self.received.append(d)
                         self.kill_read = True
+                # LOGGER.debug(f"A: Received {len(d)}")
             elif cmd == "send":
+                # LOGGER.debug(f"A: Sending {len(data)}")
                 self.send(data)
                 self.sent.append(data)
             elif cmd == "wait":
+                # LOGGER.debug(f"A: Waiting {data}")
                 time.sleep(data)
 
         # Disconnects automatically when this method ends!


### PR DESCRIPTION
<!-- Please use Github's 'Draft Pull Request' for PRs that are in-progress -->
#### Reference issue
* Change FSM to put P-DATA PDUs into the DIMSE queue instead of the `to_user_queue`
* Add `Association._sent_release` flag that is set once association release beings
* Change `Association._serve_request()` to return early if `_sent_release` flag is set
* Add warning to logging if P-DATA received during association release
* Closes #820

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
