### PR TITLE
Add redundancy to ensure sockets are closed after an association ends

### DIFF
--- a/docs/changelog/v3.0.0.rst
+++ b/docs/changelog/v3.0.0.rst
@@ -32,3 +32,5 @@ Fixes
 -----
 * Fixed a state machine error caused by receiving N-EVENT-REPORT requests during
   association release (:issue:`820`)
+* Added redundancy to ensure sockets are closed during abort and connection failure
+  (:issue:`979`)

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -226,7 +226,7 @@ class Association(threading.Thread):
         # Ensure socket is shutdown and closed
         try:
             cast(AssociationSocket, self.dul.socket)._shutdown_socket()
-        except Exception as exc:
+        except Exception:
             pass
 
         # Add short delay to ensure everything shuts down

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -224,7 +224,10 @@ class Association(threading.Thread):
             self.kill()
 
         # Ensure socket is shutdown and closed
-        self.dul.socket._shutdown_socket()
+        try:
+            cast(AssociationSocket, self.dul.socket)._shutdown_socket()
+        except Exception as exc:
+            pass
 
         # Add short delay to ensure everything shuts down
         time.sleep(0.1)

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -223,6 +223,9 @@ class Association(threading.Thread):
             evt.trigger(self, evt.EVT_ABORTED, {})
             self.kill()
 
+        # Ensure socket is shutdown and closed
+        self.dul.socket._shutdown_socket()
+
         # Add short delay to ensure everything shuts down
         time.sleep(0.1)
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -4,6 +4,7 @@ The DUL's finite state machine representation.
 
 import logging
 import queue
+import socket
 from typing import TYPE_CHECKING, cast
 
 from pynetdicom import evt
@@ -593,6 +594,9 @@ def AR_5(dul: "DULServiceProvider") -> str:
     str
         ``'Sta1'``, the next state of the state machine
     """
+    # Ensure socket is closed
+    dul.socket._shutdown_socket()
+
     assoc = dul.assoc
     remote = assoc.acceptor if assoc.is_requestor else assoc.requestor
 
@@ -881,6 +885,9 @@ def AA_4(dul: "DULServiceProvider") -> str:
     str
         ``'Sta1'``, the next state of the state machine
     """
+    # Ensure socket is closed
+    dul.socket._shutdown_socket()
+
     assoc = dul.assoc
     assoc.dimse.msg_queue.put((None, None))
 
@@ -915,6 +922,9 @@ def AA_5(dul: "DULServiceProvider") -> str:
     str
         ``'Sta1'``, the next state of the state machine
     """
+    # Ensure socket is closed
+    dul.socket._shutdown_socket()
+
     assoc = dul.assoc
     remote = assoc.acceptor if assoc.is_requestor else assoc.requestor
 

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -596,7 +596,7 @@ def AR_5(dul: "DULServiceProvider") -> str:
     # Ensure socket is closed
     try:
         cast(AssociationSocket, dul.socket)._shutdown_socket()
-    except Exception as exc:
+    except Exception:
         pass
 
     assoc = dul.assoc
@@ -890,7 +890,7 @@ def AA_4(dul: "DULServiceProvider") -> str:
     # Ensure socket is closed
     try:
         cast(AssociationSocket, dul.socket)._shutdown_socket()
-    except Exception as exc:
+    except Exception:
         pass
 
     assoc = dul.assoc
@@ -930,7 +930,7 @@ def AA_5(dul: "DULServiceProvider") -> str:
     # Ensure socket is closed
     try:
         cast(AssociationSocket, dul.socket)._shutdown_socket()
-    except Exception as exc:
+    except Exception:
         pass
 
     assoc = dul.assoc

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -4,7 +4,6 @@ The DUL's finite state machine representation.
 
 import logging
 import queue
-import socket
 from typing import TYPE_CHECKING, cast
 
 from pynetdicom import evt
@@ -18,7 +17,7 @@ from pynetdicom.pdu import (
     A_ABORT_RQ,
 )
 from pynetdicom.pdu_primitives import A_P_ABORT, A_ABORT
-from pynetdicom.transport import T_CONNECT
+from pynetdicom.transport import T_CONNECT, AssociationSocket
 
 if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.dul import DULServiceProvider
@@ -595,7 +594,10 @@ def AR_5(dul: "DULServiceProvider") -> str:
         ``'Sta1'``, the next state of the state machine
     """
     # Ensure socket is closed
-    dul.socket._shutdown_socket()
+    try:
+        cast(AssociationSocket, dul.socket)._shutdown_socket()
+    except Exception as exc:
+        pass
 
     assoc = dul.assoc
     remote = assoc.acceptor if assoc.is_requestor else assoc.requestor
@@ -886,7 +888,10 @@ def AA_4(dul: "DULServiceProvider") -> str:
         ``'Sta1'``, the next state of the state machine
     """
     # Ensure socket is closed
-    dul.socket._shutdown_socket()
+    try:
+        cast(AssociationSocket, dul.socket)._shutdown_socket()
+    except Exception as exc:
+        pass
 
     assoc = dul.assoc
     assoc.dimse.msg_queue.put((None, None))
@@ -923,7 +928,10 @@ def AA_5(dul: "DULServiceProvider") -> str:
         ``'Sta1'``, the next state of the state machine
     """
     # Ensure socket is closed
-    dul.socket._shutdown_socket()
+    try:
+        cast(AssociationSocket, dul.socket)._shutdown_socket()
+    except Exception as exc:
+        pass
 
     assoc = dul.assoc
     remote = assoc.acceptor if assoc.is_requestor else assoc.requestor

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -185,16 +185,16 @@ class AssociationSocket:
         **Events Emitted**
 
         - Evt17: Transport connection closed
+
+        .. versionchanged:: 3.0
+
+            Added the `force` keyword parameter.
         """
         if self.socket is None or self._is_connected is False:
             return
 
-        try:
-            self.socket.shutdown(socket.SHUT_RDWR)
-        except OSError:
-            pass
+        self._shutdown_socket()
 
-        self.socket.close()
         self.socket = None
         self._is_connected = False
         # Evt17: Transport connection closed
@@ -437,6 +437,14 @@ class AssociationSocket:
         except (OSError, TimeoutError):
             # Evt17: Transport connection closed
             self.event_queue.put("Evt17")
+
+    def _shutdown_socket(self) -> None:
+        """Try to shutdown and close the socket."""
+        try:
+            self.socket.shutdown(socket.SHUT_RDWR)
+            self.socket.close()
+        except Exception as exc:
+            pass
 
     def __str__(self) -> str:
         """Return the string output for ``socket``."""

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -190,10 +190,11 @@ class AssociationSocket:
 
             Added the `force` keyword parameter.
         """
+        # Always attempt to shutdown and close the socket
+        self._shutdown_socket()
+
         if self.socket is None or self._is_connected is False:
             return
-
-        self._shutdown_socket()
 
         self.socket = None
         self._is_connected = False
@@ -440,9 +441,10 @@ class AssociationSocket:
 
     def _shutdown_socket(self) -> None:
         """Try to shutdown and close the socket."""
+        sock = cast(socket.socket, self.socket)
         try:
-            self.socket.shutdown(socket.SHUT_RDWR)
-            self.socket.close()
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.close()
         except Exception as exc:
             pass
 

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -185,10 +185,6 @@ class AssociationSocket:
         **Events Emitted**
 
         - Evt17: Transport connection closed
-
-        .. versionchanged:: 3.0
-
-            Added the `force` keyword parameter.
         """
         # Always attempt to shutdown and close the socket
         self._shutdown_socket()

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -441,7 +441,7 @@ class AssociationSocket:
         try:
             sock.shutdown(socket.SHUT_RDWR)
             sock.close()
-        except Exception as exc:
+        except Exception:
             pass
 
     def __str__(self) -> str:


### PR DESCRIPTION
<!-- Please use Github's 'Draft Pull Request' for PRs that are in-progress -->
#### Reference issue
* Add redundancy to ensure socket shutdown/close during abort and connection failure
* Closes #979

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
