### PR TITLE
Catch socket deallocation exception during AA-7

### DIFF
--- a/docs/changelog/v3.0.0.rst
+++ b/docs/changelog/v3.0.0.rst
@@ -34,3 +34,5 @@ Fixes
   association release (:issue:`820`)
 * Added redundancy to ensure sockets are closed during abort and connection failure
   (:issue:`979`)
+* Handle an exception due to the socket being discarded while trying to send an abort
+  while waiting for the socket to be to be discarded 🙃 (:issue:`806`)

--- a/docs/changelog/v3.0.0.rst
+++ b/docs/changelog/v3.0.0.rst
@@ -35,4 +35,4 @@ Fixes
 * Added redundancy to ensure sockets are closed during abort and connection failure
   (:issue:`979`)
 * Handle an exception due to the socket being discarded while trying to send an abort
-  while waiting for the socket to be to be discarded 🙃 (:issue:`806`)
+  while waiting for the socket to be discarded 🙃 (:issue:`806`)

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -431,7 +431,7 @@ class AssociationSocket:
                 total_sent += nr_sent
 
             evt.trigger(self.assoc, evt.EVT_DATA_SENT, {"data": bytestream})
-        except (OSError, TimeoutError):
+        except Exception:
             # Evt17: Transport connection closed
             self.event_queue.put("Evt17")
 


### PR DESCRIPTION
<!-- Please use Github's 'Draft Pull Request' for PRs that are in-progress -->
#### Reference issue
* An `AttributeError` exception during AA-7 was occurring because the socket got reset before the A-ABORT PDU could be sent.
* Closes #806

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
