### PR TITLE
Add non-blocking abort for event handlers

### DIFF
--- a/docs/changelog/v3.0.0.rst
+++ b/docs/changelog/v3.0.0.rst
@@ -49,6 +49,10 @@ Changes
     <pynetdicom.pdu_primitives.A_ASSOCIATE.called_presentation_address>` are both now
     set using an :class:`~pynetdicom.transport.AddressInformation` instance
 
+* Added the `block` optional argument to :meth:`Association.abort()
+  <pynetdicom.association.Association.abort>` to allow for operation in non-blocking
+  mode.
+
 
 Enhancements
 ------------
@@ -69,3 +73,5 @@ Fixes
   (:issue:`979`)
 * Handle an exception due to the socket being discarded while trying to send an abort
   while waiting for the socket to be discarded 🙃 (:issue:`806`)
+* Fixed :meth:`Association.abort()<pynetdicom.association.Association.abort>` causing
+  a deadlock when called within event handlers (:issue:`912`)

--- a/pynetdicom/events.py
+++ b/pynetdicom/events.py
@@ -357,6 +357,11 @@ def trigger(
     if not handlers or handlers[0] is None:
         return None
 
+    # Use the non-blocking abort during during notification event handlers
+    #   The trigger for intervention event handlers sets the abort method
+    if isinstance(event, NotificationEvent):
+        setattr(assoc, "abort", assoc._abort_nonblocking)
+
     evt = Event(assoc, event, attrs or {})
 
     try:
@@ -376,6 +381,8 @@ def trigger(
             else:
                 func(evt)
     except Exception as exc:
+        setattr(assoc, "abort", assoc._abort_blocking)
+
         # Intervention exceptions get raised
         if isinstance(event, InterventionEvent):
             raise
@@ -386,6 +393,8 @@ def trigger(
             f"event handler '{func.__name__}'"
         )
         LOGGER.exception(exc)
+
+    setattr(assoc, "abort", assoc._abort_blocking)
 
     return None
 

--- a/pynetdicom/tests/test_service_class.py
+++ b/pynetdicom/tests/test_service_class.py
@@ -8,7 +8,7 @@ from pydicom.dataset import Dataset
 
 from pynetdicom import build_context
 from pynetdicom.dimse_primitives import C_STORE, C_GET, C_MOVE, C_CANCEL
-from pynetdicom.service_class import StorageServiceClass, ServiceClass
+from pynetdicom.service_class import StorageServiceClass, ServiceClass, attempt
 
 
 class DummyAssoc:
@@ -142,3 +142,10 @@ class TestServiceClass:
         assert service.is_cancelled(2) is False
         assert service.is_cancelled(3) is False
         assert cancel not in assoc.dimse.cancel_req.values()
+
+
+def test_attempt_non_assoc():
+    with attempt(None, None, 1) as ctx:
+        msg = "No association instance has been set"
+        with pytest.raises(ValueError, match=msg):
+            ctx.assoc


### PR DESCRIPTION
<!-- Please use Github's 'Draft Pull Request' for PRs that are in-progress -->
#### Reference issue
* Adds `abort` kwarg to `Association.abort()`
* Fixes `Association.abort()` calls deadlocking the DUL reactor
* Closes #912

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
