### PR TITLE
Fix issue with using a hostname without IPv6

### DIFF
--- a/docs/changelog/v3.1.0.rst
+++ b/docs/changelog/v3.1.0.rst
@@ -7,3 +7,4 @@ Fixes
 -----
 
 * Fixed the default logging handlers for N-ACTION treating *Action Type ID* as mandatory (:issue:`1027`)
+* Fixed being unable to resolve IPv4 address when using the hostname (:issue:`1033`, :pr:`1034`)

--- a/pynetdicom/tests/test_transport.py
+++ b/pynetdicom/tests/test_transport.py
@@ -11,6 +11,7 @@ from struct import pack
 import sys
 import threading
 import time
+from unittest import mock
 
 import pytest
 
@@ -56,6 +57,14 @@ DATASET = dcmread(os.path.join(DCM_DIR, "RTImageStorage.dcm"))
 
 # debug_logger()
 
+_original_getaddrinfo = socket.getaddrinfo
+
+
+def getaddrinfo_no_ipv4(*args, **kwargs):
+    """Calls socket.getaddrinfo and leaves out the IPv4 results."""
+    entries = _original_getaddrinfo(*args, **kwargs)
+    return [addr for addr in entries if addr[0] != socket.AF_INET]
+
 
 class TestAddressInformation:
     """Tests for AssociationInformation."""
@@ -93,6 +102,20 @@ class TestAddressInformation:
         assert addr.scope_id == 11
         assert addr.as_tuple == ("::1", 0, 10, 11)
 
+    def test_no_ipv4(self):
+        with mock.patch("socket.getaddrinfo", new=getaddrinfo_no_ipv4):
+            addr = AddressInformation("localhost", 0)
+            assert addr.address == "::1"
+            assert addr.port == 0
+
+            addr = AddressInformation("", 0)
+            assert addr.address in ("::0", "::")
+            assert addr.port == 0
+
+            # IPv6 does not use broadcast.
+            with pytest.raises(socket.gaierror):
+                AddressInformation("<broadcast>", 0)
+
     def test_from_tuple(self):
         addr = AddressInformation.from_tuple(("localhost", get_port()))
         assert isinstance(addr, AddressInformation)
@@ -106,7 +129,7 @@ class TestAddressInformation:
 
         addr = AddressInformation.from_tuple(("::0", get_port("remote")))
         assert isinstance(addr, AddressInformation)
-        assert addr.address == "::0"
+        assert addr.address in ("::0", "::")
         assert addr.port == get_port("remote")
 
     def test_from_add_port(self):
@@ -117,14 +140,14 @@ class TestAddressInformation:
 
         addr = AddressInformation.from_addr_port("::0", get_port("remote"))
         assert isinstance(addr, AddressInformation)
-        assert addr.address == "::0"
+        assert addr.address in ("::0", "::")
         assert addr.port == get_port("remote")
         assert addr.flowinfo == 0
         assert addr.scope_id == 0
 
         addr = AddressInformation.from_addr_port(("::0", 12, 13), get_port("remote"))
         assert isinstance(addr, AddressInformation)
-        assert addr.address == "::0"
+        assert addr.address in ("::0", "::")
         assert addr.port == get_port("remote")
         assert addr.flowinfo == 12
         assert addr.scope_id == 13
@@ -143,7 +166,7 @@ class TestAddressInformation:
         assert addr.address == "192.168.0.1"
         assert addr.address_family == socket.AF_INET
         addr.address = "::0"
-        assert addr.address == "::0"
+        assert addr.address in ("::0", "::")
         assert addr.address_family == socket.AF_INET6
         addr.address = "192.168.0.1"
         assert addr.address == "192.168.0.1"
@@ -164,9 +187,9 @@ class TestTConnect:
     def test_address_request(self):
         """Test init with an A-ASSOCIATE primitive"""
         request = A_ASSOCIATE()
-        request.called_presentation_address = AddressInformation("123.4", 12)
+        request.called_presentation_address = AddressInformation("1.2.3.4", 12)
         conn = T_CONNECT(request)
-        assert conn.address == ("123.4", 12)
+        assert conn.address == ("1.2.3.4", 12)
         assert conn.request is request
 
         msg = r"A connection attempt has not yet been made"
@@ -176,7 +199,7 @@ class TestTConnect:
     def test_result_setter(self):
         """Test setting the result value."""
         request = A_ASSOCIATE()
-        request.called_presentation_address = AddressInformation("123.4", 12)
+        request.called_presentation_address = AddressInformation("1.2.3.4", 12)
         conn = T_CONNECT(request)
 
         msg = r"Invalid connection result 'foo'"
@@ -191,7 +214,7 @@ class TestTConnect:
 
     def test_address_inf(self):
         request = A_ASSOCIATE()
-        request.called_presentation_address = AddressInformation("123.4", 12)
+        request.called_presentation_address = AddressInformation("1.2.3.4", 12)
         conn = T_CONNECT(request)
         assert conn.address_info is request.called_presentation_address
 

--- a/pynetdicom/tests/test_transport.py
+++ b/pynetdicom/tests/test_transport.py
@@ -117,7 +117,7 @@ class TestAddressInformation:
             assert addr.port == 0
 
             # IPv6 does not use broadcast.
-            with pytest.raises(socket.gaierror):
+            with pytest.raises(socket.gaierror, match="Address resolution failed"):
                 AddressInformation("<broadcast>", 0)
 
     def test_from_tuple(self):

--- a/pynetdicom/tests/test_transport.py
+++ b/pynetdicom/tests/test_transport.py
@@ -103,10 +103,14 @@ class TestAddressInformation:
         assert addr.as_tuple == ("::1", 0, 10, 11)
 
     def test_no_ipv4(self):
+        # Check to ensure we have IPv6 entries
+        localhost_entries = getaddrinfo_no_ipv4("localhost", 0)
+
         with mock.patch("socket.getaddrinfo", new=getaddrinfo_no_ipv4):
-            addr = AddressInformation("localhost", 0)
-            assert addr.address == "::1"
-            assert addr.port == 0
+            if localhost_entries:
+                addr = AddressInformation("localhost", 0)
+                assert addr.address == "::1"
+                assert addr.port == 0
 
             addr = AddressInformation("", 0)
             assert addr.address in ("::0", "::")
@@ -171,6 +175,10 @@ class TestAddressInformation:
         addr.address = "192.168.0.1"
         assert addr.address == "192.168.0.1"
         assert addr.address_family == socket.AF_INET
+
+    def test_resolve_hostname(self):
+        with pytest.raises(socket.gaierror):
+            AddressInformation("remotehost", 0)
 
 
 class TestTConnect:

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -107,22 +107,21 @@ class AddressInformation:
             value = "255.255.255.255" if value == "<broadcast>" else value
             flags = 0
         else:
-            # getaddrinfo interprets "" as localhost. Set the AI_PASSIVE flag
+            # getaddrinfo interprets "" as "0.0.0.0" or "::". Set the AI_PASSIVE flag
             # to return an address that can be used with BIND.
-            value = None
             flags = socket.AI_PASSIVE
 
         # getaddrinfo translates a hostname into IPv4 and/or IPv6-addresses.
-        entries = socket.getaddrinfo(value, 0, flags=flags)
+        entries = socket.getaddrinfo(value if value else None, 0, flags=flags)
 
         # Use the first IPv4 address, or the first IPv6 address if there are no
         # IPv4 addresses available.
         ipv4_entries = [addr for addr in entries if addr[0] == socket.AF_INET]
         ipv6_entries = [addr for addr in entries if addr[0] == socket.AF_INET6]
         if ipv4_entries:
-            self._addr = ipv4_entries[0][4][0]
+            self._addr = cast(str, ipv4_entries[0][4][0])
         elif ipv6_entries:
-            self._addr = ipv6_entries[0][4][0]
+            self._addr = cast(str, ipv6_entries[0][4][0])
         else:
             raise socket.gaierror("Address resolution failed")
 


### PR DESCRIPTION
#### Reference issue
When using a hostname instead of an IP-address, the AddressInformation.address_family function would return AF_INET6. This doesn't work in an environment without IPv6 such as in (some) Docker containers.
Furthermore, a (rather hypothetical) scenario where IPv4 is not available was not supported.

#### Fixes
To fix these issues, AddressInformation.address now does DNS lookup. This means that the address_family/is_ipv4/is_ipv6 functions now work as intended. IPv4 address are preferred over IPv6 for compatibility.

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [ ] ~Apps updated and tested (if relevant)~
