### PR TITLE
Use wildcard to fix warning banner

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -6,48 +6,48 @@
   },
   {
     "name": "3.0 (stable)",
-    "version": "3.0",
+    "version": "3.0.*",
     "url": "https://pydicom.github.io/pynetdicom/stable/",
     "preferred": true
   },
   {
     "name": "2.1",
-    "version": "2.1",
+    "version": "2.1.*",
     "url": "https://pydicom.github.io/pynetdicom/2.1/"
   },
   {
     "name": "2.0",
-    "version": "2.0",
+    "version": "2.0.*",
     "url": "https://pydicom.github.io/pynetdicom/2.0/"
   },
   {
     "name": "1.5",
-    "version": "1.5",
+    "version": "1.5.*",
     "url": "https://pydicom.github.io/pynetdicom/1.5/"
   },
   {
     "name": "1.4",
-    "version": "1.4",
+    "version": "1.4.*",
     "url": "https://pydicom.github.io/pynetdicom/1.4/"
   },
   {
     "name": "1.3",
-    "version": "1.3",
+    "version": "1.3.*",
     "url": "https://pydicom.github.io/pynetdicom/1.3/"
   },
   {
     "name": "1.2",
-    "version": "1.2",
+    "version": "1.2.*",
     "url": "https://pydicom.github.io/pynetdicom/1.2/"
   },
   {
     "name": "1.1",
-    "version": "1.1",
+    "version": "1.1.*",
     "url": "https://pydicom.github.io/pynetdicom/1.1/"
   },
   {
     "name": "1.0",
-    "version": "1.0",
+    "version": "1.0.*",
     "url": "https://pydicom.github.io/pynetdicom/1.0/"
   }
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,10 +183,17 @@ html_theme = "pydata_sphinx_theme"
 # html_theme_path = [pydata_sphinx_theme.get_html_theme_path()]
 
 # Define the version we use for matching in the version switcher.
-json_url = "https://pydicom.github.io/pynetdicom/dev/_static/switcher.json"
-version_match = "dev" if "dev" in pynetdicom.__version__ else pynetdicom.__version__
-if version_match == "dev":
+# Annoyingly the dropdown menu label requires `version_match` to be an exact match
+#   for the version in switcher.json, while the warning banner requires a wildcard
+#   match to the package version (not `version_match`)
+if "dev" in pynetdicom.__version__:
+    version_match = "dev"
+    # 'version' attribute in the JSON file should use MAJOR.MINOR.*
     json_url = "_static/switcher.json"
+else:
+    # Match to MAJOR.MINOR.*
+    version_match = ".".join(pynetdicom.__version__.split(".")[:2]) + ".*"
+    json_url = "https://pydicom.github.io/pynetdicom/dev/_static/switcher.json"
 
 html_theme_options = {
     "logo": {


### PR DESCRIPTION
I can see myself on my deathbed, still trying to get this working properly.

The dropdown buttons use an equivalency match for 'version' value in switcher.JSON to the `version_match` attr in the conf.py file, BUT the warning banner uses a different method for matching based on [compare-versions](https://github.com/omichelsen/compare-versions), so one can match and the other not. I think the solution is to use MAJOR.MINOR.* (or MAJOR.MINOR.PATCH) in both switcher.json and conf.py, but we'll see.

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
