### PR TITLE
Fix missing public transfer syntaxes

### DIFF
--- a/pynetdicom/__init__.py
+++ b/pynetdicom/__init__.py
@@ -2,10 +2,23 @@
 
 import logging
 
+from pydicom._uid_dict import UID_dictionary
 from pydicom.uid import UID
 
 from ._version import __version__
 
+
+# fmt: off
+# Update pydicom's UID dictionary with any missing transfer syntaxes
+UID_dictionary.update(
+    {
+        '1.2.840.10008.1.2.4.110': ('JPEG XL Lossless', 'Transfer Syntax', '', '', 'JPEGXLLossless'),
+        '1.2.840.10008.1.2.4.111': ('JPEG XL JPEG Recompression', 'Transfer Syntax', '', '', 'JPEGXLJPEGRecompression'),
+        '1.2.840.10008.1.2.4.112': ('JPEG XL', 'Transfer Syntax', '', '', 'JPEGXL'),
+        '1.2.840.10008.1.2.8.1': ('Deflated Image Frame Compression', 'Transfer Syntax', '', '', 'DeflatedImageFrameCompression'),
+    }
+)
+# fmt: on
 
 _version = __version__.split(".")[:3]
 

--- a/pynetdicom/presentation.py
+++ b/pynetdicom/presentation.py
@@ -119,14 +119,7 @@ SCP_SCU_ROLES: _RoleType = {
         (False, True): CONTEXT_REJECTED,  # Invalid
     },
 }
-# Transfer Syntaxes not in pydicom v2.4
-_PYDICOM_ADDITIONS = [
-    "1.2.840.10008.1.2.4.201",  # HTJ2KLossless
-    "1.2.840.10008.1.2.4.202",  # HTJ2KLosslessRPCL
-    "1.2.840.10008.1.2.4.203",  # HTJ2K
-    "1.2.840.10008.1.2.4.204",  # JPIPHTJ2KReferenced
-    "1.2.840.10008.1.2.4.205",  # JPIPHTJ2KReferencedDeflate
-]
+
 
 class PresentationContext:
     """A Presentation Context primitive.
@@ -269,24 +262,17 @@ class PresentationContext:
             LOGGER.error("'transfer_syntax' contains an invalid UID")
             raise ValueError("'transfer_syntax' contains an invalid UID")
 
-        if syntax and not syntax.is_valid:
-            LOGGER.warning(f"The Transfer Syntax Name '{syntax}' is non-conformant")
-
-        # If the transfer syntax is rejected we may add an empty str
+        # If the transfer syntax is rejected we may receive an empty str
         if syntax not in self._transfer_syntax and syntax != "":
             if not syntax.is_valid:
                 LOGGER.warning(
-                    "A non-conformant UID has been added to 'transfer_syntax'"
+                    f"A non-conformant UID has been added to 'transfer_syntax': '{syntax}'"
                 )
 
-            if (
-                not syntax.is_private
-                and not syntax.is_transfer_syntax
-                and syntax not in _PYDICOM_ADDITIONS
-            ):
+            if not syntax.is_private and not syntax.is_transfer_syntax:
                 LOGGER.warning(
-                    "A UID has been added to 'transfer_syntax' that is not a "
-                    f"transfer syntax: '{syntax}'"
+                    "A UID has been added to 'transfer_syntax' that is not a known "
+                    f"public transfer syntax: '{syntax}'"
                 )
 
             self._transfer_syntax.append(syntax)

--- a/pynetdicom/tests/test_presentation.py
+++ b/pynetdicom/tests/test_presentation.py
@@ -10,7 +10,7 @@ from pydicom._uid_dict import UID_dictionary
 from pydicom.uid import UID
 
 from pynetdicom import AE, _config
-from pynetdicom._globals import DEFAULT_TRANSFER_SYNTAXES
+from pynetdicom._globals import DEFAULT_TRANSFER_SYNTAXES, ALL_TRANSFER_SYNTAXES
 from pynetdicom.pdu_primitives import SCP_SCU_RoleSelectionNegotiation
 from pynetdicom.presentation import (
     build_context,
@@ -120,18 +120,21 @@ class TestPresentationContext:
 
         msg = r"'transfer_syntax' contains an invalid UID"
         with pytest.raises(ValueError, match=msg):
-            pc.add_transfer_syntax("1.2.3.")
+            with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
+                pc.add_transfer_syntax("1.2.3.")
 
         assert msg in caplog.text
 
         pc.add_transfer_syntax("1.2.840.10008.1.1")
         assert (
-            "A UID has been added to 'transfer_syntax' that is not a "
+            "A UID has been added to 'transfer_syntax' that is not a known public "
             "transfer syntax" in caplog.text
         )
 
         _config.ENFORCE_UID_CONFORMANCE = False
-        pc.add_transfer_syntax("1.2.3.")
+        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
+            pc.add_transfer_syntax("1.2.3.")
+
         assert "1.2.3." in pc.transfer_syntax
 
     def test_add_private_transfer_syntax(self):
@@ -294,14 +297,18 @@ class TestPresentationContext:
 
         msg = "Invalid 'abstract_syntax' value '1.4.1.' - UID is non-conformant"
         with pytest.raises(ValueError, match=msg):
-            pc.abstract_syntax = UID("1.4.1.")
+            with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
+                pc.abstract_syntax = UID("1.4.1.")
+
         assert pc.abstract_syntax is None
 
         _config.ENFORCE_UID_CONFORMANCE = False
-        pc.abstract_syntax = UID("1.4.1.")
 
-        assert pc.abstract_syntax == UID("1.4.1.")
-        assert isinstance(pc.abstract_syntax, UID)
+        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
+            pc.abstract_syntax = UID("1.4.1.")
+
+            assert pc.abstract_syntax == UID("1.4.1.")
+            assert isinstance(pc.abstract_syntax, UID)
 
         assert msg in caplog.text
 
@@ -337,7 +344,8 @@ class TestPresentationContext:
         caplog.set_level(logging.DEBUG, logger="pynetdicom.presentation")
         pc = PresentationContext()
         pc.context_id = 1
-        pc.transfer_syntax = ["1.4.1.", "1.2.840.10008.1.2"]
+        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
+            pc.transfer_syntax = ["1.4.1.", "1.2.840.10008.1.2"]
 
         assert pc.transfer_syntax == ["1.4.1.", "1.2.840.10008.1.2"]
         assert "A non-conformant UID has been added to 'transfer_syntax'" in caplog.text
@@ -432,6 +440,18 @@ class TestPresentationContext:
         assert "1.2.3" == repr(cx)
         cx = build_context("1.2.840.10008.1.1")
         assert "Verification SOP Class" == repr(cx)
+
+    def test_transfer_syntaxes_dont_warn(self, caplog):
+        """Test that all transfer syntaxes are known to pydicom"""
+        caplog.set_level(logging.WARNING, logger="pynetdicom.presentation")
+        for ts in ALL_TRANSFER_SYNTAXES:
+            cx = build_context("1.2.3", ts)
+
+        for ts in DEFAULT_TRANSFER_SYNTAXES:
+            cx = build_context("1.2.3", ts)
+
+        assert caplog.text == ""
+
 
 
 class TestNegotiateAsAcceptor:

--- a/pynetdicom/tests/test_presentation.py
+++ b/pynetdicom/tests/test_presentation.py
@@ -120,8 +120,7 @@ class TestPresentationContext:
 
         msg = r"'transfer_syntax' contains an invalid UID"
         with pytest.raises(ValueError, match=msg):
-            with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
-                pc.add_transfer_syntax("1.2.3.")
+            pc.add_transfer_syntax("1.2.3.")
 
         assert msg in caplog.text
 
@@ -132,9 +131,7 @@ class TestPresentationContext:
         )
 
         _config.ENFORCE_UID_CONFORMANCE = False
-        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
-            pc.add_transfer_syntax("1.2.3.")
-
+        pc.add_transfer_syntax("1.2.3.")
         assert "1.2.3." in pc.transfer_syntax
 
     def test_add_private_transfer_syntax(self):
@@ -297,18 +294,15 @@ class TestPresentationContext:
 
         msg = "Invalid 'abstract_syntax' value '1.4.1.' - UID is non-conformant"
         with pytest.raises(ValueError, match=msg):
-            with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
-                pc.abstract_syntax = UID("1.4.1.")
+            pc.abstract_syntax = UID("1.4.1.")
 
         assert pc.abstract_syntax is None
 
         _config.ENFORCE_UID_CONFORMANCE = False
 
-        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
-            pc.abstract_syntax = UID("1.4.1.")
-
-            assert pc.abstract_syntax == UID("1.4.1.")
-            assert isinstance(pc.abstract_syntax, UID)
+        pc.abstract_syntax = UID("1.4.1.")
+        assert pc.abstract_syntax == UID("1.4.1.")
+        assert isinstance(pc.abstract_syntax, UID)
 
         assert msg in caplog.text
 
@@ -344,8 +338,7 @@ class TestPresentationContext:
         caplog.set_level(logging.DEBUG, logger="pynetdicom.presentation")
         pc = PresentationContext()
         pc.context_id = 1
-        with pytest.warns(UserWarning, match="Invalid value for VR UI:"):
-            pc.transfer_syntax = ["1.4.1.", "1.2.840.10008.1.2"]
+        pc.transfer_syntax = ["1.4.1.", "1.2.840.10008.1.2"]
 
         assert pc.transfer_syntax == ["1.4.1.", "1.2.840.10008.1.2"]
         assert "A non-conformant UID has been added to 'transfer_syntax'" in caplog.text


### PR DESCRIPTION
#### Reference issue
* Register the missing public transfer syntaxes with pydicom - not that it'll be needed in the actual 3.1 release
* Add a test to ensure all transfer syntaxes in pynetdicom are registered with pydicom
* Remove a redundant transfer syntax check and warning

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [x] Apps updated and tested (if relevant)
