### PR TITLE
Fix missing transfer syntax warnings

### DIFF
--- a/docs/changelog/index.rst
+++ b/docs/changelog/index.rst
@@ -7,6 +7,7 @@ Releases
 .. toctree::
    :maxdepth: 1
 
+   v3.0.4
    v3.0.3
    v3.0.2
    v3.0.1

--- a/docs/changelog/v3.0.4.rst
+++ b/docs/changelog/v3.0.4.rst
@@ -1,0 +1,10 @@
+.. _v3.0.4:
+
+3.0.4
+=====
+
+Fixes
+-----
+
+Fixed unknown transfer syntax warnings due to pydicom v3.0 using an older version of the
+DICOM Standard.

--- a/pynetdicom/__init__.py
+++ b/pynetdicom/__init__.py
@@ -2,10 +2,23 @@
 
 import logging
 
+from pydicom._uid_dict import UID_dictionary
 from pydicom.uid import UID
 
 from ._version import __version__
 
+
+# fmt: off
+# Update pydicom's UID dictionary with any missing transfer syntaxes
+UID_dictionary.update(
+    {
+        '1.2.840.10008.1.2.4.110': ('JPEG XL Lossless', 'Transfer Syntax', '', '', 'JPEGXLLossless'),
+        '1.2.840.10008.1.2.4.111': ('JPEG XL JPEG Recompression', 'Transfer Syntax', '', '', 'JPEGXLJPEGRecompression'),
+        '1.2.840.10008.1.2.4.112': ('JPEG XL', 'Transfer Syntax', '', '', 'JPEGXL'),
+        '1.2.840.10008.1.2.8.1': ('Deflated Image Frame Compression', 'Transfer Syntax', '', '', 'DeflatedImageFrameCompression'),
+    }
+)
+# fmt: on
 
 _version = __version__.split(".")[:3]
 

--- a/pynetdicom/presentation.py
+++ b/pynetdicom/presentation.py
@@ -119,14 +119,7 @@ SCP_SCU_ROLES: _RoleType = {
         (False, True): CONTEXT_REJECTED,  # Invalid
     },
 }
-# Transfer Syntaxes not in pydicom v2.4
-_PYDICOM_ADDITIONS = [
-    "1.2.840.10008.1.2.4.201",  # HTJ2KLossless
-    "1.2.840.10008.1.2.4.202",  # HTJ2KLosslessRPCL
-    "1.2.840.10008.1.2.4.203",  # HTJ2K
-    "1.2.840.10008.1.2.4.204",  # JPIPHTJ2KReferenced
-    "1.2.840.10008.1.2.4.205",  # JPIPHTJ2KReferencedDeflate
-]
+
 
 class PresentationContext:
     """A Presentation Context primitive.
@@ -279,11 +272,7 @@ class PresentationContext:
                     "A non-conformant UID has been added to 'transfer_syntax'"
                 )
 
-            if (
-                not syntax.is_private
-                and not syntax.is_transfer_syntax
-                and syntax not in _PYDICOM_ADDITIONS
-            ):
+            if not syntax.is_private and not syntax.is_transfer_syntax:
                 LOGGER.warning(
                     "A UID has been added to 'transfer_syntax' that is not a "
                     f"transfer syntax: '{syntax}'"

--- a/pynetdicom/tests/test_presentation.py
+++ b/pynetdicom/tests/test_presentation.py
@@ -10,7 +10,7 @@ from pydicom._uid_dict import UID_dictionary
 from pydicom.uid import UID
 
 from pynetdicom import AE, _config
-from pynetdicom._globals import DEFAULT_TRANSFER_SYNTAXES
+from pynetdicom._globals import DEFAULT_TRANSFER_SYNTAXES, ALL_TRANSFER_SYNTAXES
 from pynetdicom.pdu_primitives import SCP_SCU_RoleSelectionNegotiation
 from pynetdicom.presentation import (
     build_context,
@@ -432,6 +432,17 @@ class TestPresentationContext:
         assert "1.2.3" == repr(cx)
         cx = build_context("1.2.840.10008.1.1")
         assert "Verification SOP Class" == repr(cx)
+
+    def test_transfer_syntaxes_dont_warn(self, caplog):
+        """Test that all transfer syntaxes are known to pydicom"""
+        caplog.set_level(logging.WARNING, logger="pynetdicom.presentation")
+        for ts in ALL_TRANSFER_SYNTAXES:
+            cx = build_context("1.2.3", ts)
+
+        for ts in DEFAULT_TRANSFER_SYNTAXES:
+            cx = build_context("1.2.3", ts)
+
+        assert caplog.text == ""
 
 
 class TestNegotiateAsAcceptor:

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -852,12 +852,12 @@ class AssociationServer(TCPServer):
         self.address_info = AddressInformation.from_tuple(address)
         self.address_family = self.address_info.address_family
         self.allow_reuse_address = True
-        self.server_address: tuple[str, int] | tuple[str, int, int, int] = address  # type: ignore[assignment]
+        self.server_address: tuple[str, int] | tuple[str, int, int, int] = address
         self.socket: socket.socket | None = None  # type: ignore[assignment]
 
         request_handler = request_handler or RequestHandler
 
-        super().__init__(address, request_handler, bind_and_activate=True)  # type: ignore[arg-type]
+        super().__init__(address, request_handler, bind_and_activate=True)
 
         self.timeout = 60
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ maintainers = [
 ]
 name = "pynetdicom"
 readme = "README.rst"
-version = "3.0.3"
+version = "3.0.4"
 requires-python = ">=3.10"
 dependencies = ["pydicom >=3, <4"]
 


### PR DESCRIPTION
Fixes missing transfer syntax warnings

#### Tasks
- [x] Unit tests added that reproduce issue or prove feature is working
- [x] Fix or feature added
- [x] Documentation and examples updated (if relevant)
- [x] Unit tests passing and coverage at 100% after adding fix/feature
- [x] Type annotations updated and passing with mypy
- [x] Apps updated and tested (if relevant)
