### PR TITLE
Get rid of `# pylint` pragmas

### DIFF
--- a/pynetdicom/acse.py
+++ b/pynetdicom/acse.py
@@ -78,8 +78,7 @@ class ACSE:
             default values for the number of operations invoked/performed
             (1, 1).
         """
-        # pylint: disable=broad-except
-        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)
+        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)   # noqa: B010
 
         try:
             # Response is always ignored as async ops is not supported
@@ -113,8 +112,7 @@ class ACSE:
             The {SOP Class UID : SOPClassCommonExtendedNegotiation} items for
             the accepted SOP Class Common Extended negotiation items.
         """
-        # pylint: disable=broad-except
-        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)
+        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)   # noqa: B010
 
         try:
             rsp = evt.trigger(
@@ -155,8 +153,7 @@ class ACSE:
         list of pdu_primitives.SOPClassExtendedNegotiation
             The SOP Class Extended Negotiation items to be sent in response
         """
-        # pylint: disable=broad-except
-        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)
+        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)   # noqa: B010
 
         try:
             user_response = evt.trigger(
@@ -207,8 +204,7 @@ class ACSE:
             The negotiation response, if a positive response is requested,
             otherwise None.
         """
-        # pylint: disable=broad-except
-        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)
+        setattr(self.assoc, "abort", self.assoc._abort_nonblocking)  # noqa: B010
 
         # The UserIdentityNegotiation (request) item
         req = self.requestor.user_identity
@@ -361,9 +357,7 @@ class ACSE:
 
         # SOP Class Common Extended Negotiation items
         #   Note: No response items are allowed
-        # pylint: disable=protected-access
         self.acceptor._common_ext = self._check_sop_class_common_extended()
-        # pylint: enable=protected-access
 
         # Asynchronous Operations Window Negotiation items
         if self.requestor.asynchronous_operations != (1, 1):
@@ -382,7 +376,6 @@ class ACSE:
             reject_assoc_rsd = (0x02, 0x03, 0x02)
 
         if reject_assoc_rsd:
-            # pylint: disable=no-value-for-parameter
             LOGGER.info("Rejecting Association")
             self.send_reject(*reject_assoc_rsd)
             evt.trigger(self.assoc, evt.EVT_REJECTED, {})
@@ -410,13 +403,11 @@ class ACSE:
                 rq_roles,
             )
 
-        # pylint: disable=protected-access
         # Accepted contexts are stored as {context ID : context}
         self.assoc._accepted_cx = {
             cast(int, cx.context_id): cx for cx in result if cx.result == 0x00
         }
         self.assoc._rejected_cx = [cx for cx in result if cx.result != 0x00]
-        # pylint: enable=protected-access
 
         # Add any SCP/SCU Role Selection Negotiation response items
         for role_item in ac_roles:
@@ -498,7 +489,6 @@ class ACSE:
                     ac_roles,
                 )
 
-                # pylint: disable=protected-access
                 # Accepted contexts are stored as {context ID : context}
                 self.assoc._accepted_cx = {
                     cast(int, cx.context_id): cx
@@ -508,7 +498,6 @@ class ACSE:
                 self.assoc._rejected_cx = [
                     cx for cx in negotiated_contexts if cx.result != 0x00
                 ]
-                # pylint: enable=protected-access
 
                 evt.trigger(self.assoc, evt.EVT_ACCEPTED, {})
 

--- a/pynetdicom/ae.py
+++ b/pynetdicom/ae.py
@@ -53,7 +53,6 @@ class ApplicationEntity:
     or both.
     """
 
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
     def __init__(self, ae_title: str = "PYNETDICOM") -> None:
         """Create a new Application Entity.
 

--- a/pynetdicom/association.py
+++ b/pynetdicom/association.py
@@ -20,7 +20,6 @@ from pydicom.dataset import Dataset
 from pydicom.tag import BaseTag
 from pydicom.uid import UID, ImplicitVRLittleEndian, ExplicitVRBigEndian
 
-# pylint: disable=no-name-in-module
 from pynetdicom.acse import ACSE
 from pynetdicom import _config, evt
 from pynetdicom.dimse import DIMSEServiceProvider
@@ -90,7 +89,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from pynetdicom.transport import AssociationServer, AssociationSocket
 
 
-# pylint: enable=no-name-in-module
 LOGGER = logging.getLogger(__name__)
 HandlerType = dict[
     evt.EventType,
@@ -580,7 +578,6 @@ class Association(threading.Thread):
                 "or 'acceptor'"
             )
 
-        # pylint: disable=attribute-defined-outside-init
         self._mode = mode
 
     @property
@@ -2213,7 +2210,6 @@ class Association(threading.Thread):
                 #   statuses should contain an Identifier dataset
                 #   with a (0008,0058) Failed SOP Instance UID List
                 #    element however this can't be assumed
-                # pylint: disable=broad-except
                 with self.lock:
                     try:
                         identifier = decode(
@@ -2438,7 +2434,6 @@ class Association(threading.Thread):
             b: BytesIO = rsp.ActionReply  # type: ignore
             if b and b.getvalue() != b"":
                 # Attempt to decode the response's dataset
-                # pylint: disable=broad-except
                 try:
                     action_reply = decode(
                         b,
@@ -2676,7 +2671,6 @@ class Association(threading.Thread):
             b: BytesIO = rsp.AttributeList  # type: ignore
             if b and b.getvalue() != b"":
                 # Attempt to decode the response's dataset
-                # pylint: disable=broad-except
                 try:
                     attribute_list = decode(
                         b,
@@ -3007,7 +3001,6 @@ class Association(threading.Thread):
             b: BytesIO = rsp.EventReply  # type: ignore
             if b and b.getvalue() != b"":
                 # Attempt to decode the response"s dataset
-                # pylint: disable=broad-except
                 try:
                     event_reply = decode(
                         b,
@@ -3215,7 +3208,6 @@ class Association(threading.Thread):
             b: BytesIO = rsp.AttributeList  # type: ignore
             if b and b.getvalue() != b"":
                 # Attempt to decode the response"s dataset
-                # pylint: disable=broad-except
                 try:
                     attribute_list = decode(
                         b,
@@ -3466,7 +3458,6 @@ class Association(threading.Thread):
             b: BytesIO = rsp.AttributeList  # type: ignore
             if b and b.getvalue() != b"":
                 # Attempt to decode the response's dataset
-                # pylint: disable=broad-except
                 try:
                     attribute_list = decode(
                         b,
@@ -3824,7 +3815,6 @@ class ServiceUser:
 
             return items
 
-        # pylint: disable=unidiomatic-typecheck
         for item in self.user_information:
             if type(item) in self._ext_neg.keys():
                 items.append(item)
@@ -4177,7 +4167,6 @@ class ServiceUser:
                 "has started"
             )
 
-        # pylint: disable=unidiomatic-typecheck
         if type(item) in self._ext_neg:
             # Do nothing if item not in _ext_neg
             if item in self._ext_neg[type(item)]:

--- a/pynetdicom/dimse.py
+++ b/pynetdicom/dimse.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, cast
 
 from pynetdicom import evt
 
-# pylint: disable=no-name-in-module
 from pynetdicom.dimse_messages import (
     C_STORE_RQ,
     C_STORE_RSP,
@@ -38,7 +37,6 @@ from pynetdicom.dimse_messages import (
     DIMSEMessage,
 )
 
-# pylint: enable=no-name-in-module
 from pynetdicom.dimse_primitives import (
     C_STORE,
     C_FIND,

--- a/pynetdicom/dimse_messages.py
+++ b/pynetdicom/dimse_messages.py
@@ -436,7 +436,6 @@ class DIMSEMessage:
 
                     # Command Set is always encoded Implicit VR Little Endian
                     #   decode(dataset, is_implicit_VR, is_little_endian)
-                    # pylint: disable=attribute-defined-outside-init
                     self.command_set = decode(self.encoded_command_set, True, True)
 
                     # Determine which DIMSE Message class to use
@@ -745,7 +744,6 @@ class DIMSEMessage:
             :ref:`pynetdicom.dimse_primitives<api_dimse_primitives>`
             to convert to the current ``DIMSEMessage`` object.
         """
-        # pylint: disable=too-many-branches,too-many-statements
         cls_type_name = self.__class__.__name__.replace("_", "-")
         if cls_type_name not in _COMMAND_SET_KEYWORDS:
             raise ValueError(

--- a/pynetdicom/dimse_primitives.py
+++ b/pynetdicom/dimse_primitives.py
@@ -44,10 +44,6 @@ DimseServiceType: TypeAlias = (
 DimsePrimitiveType: TypeAlias = "C_CANCEL | DimseServiceType"
 
 
-# pylint: disable=invalid-name
-# pylint: disable=attribute-defined-outside-init
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=anomalous-backslash-in-string
 class DIMSEPrimitive:
     """Base class for the DIMSE primitives."""
 

--- a/pynetdicom/dsutils.py
+++ b/pynetdicom/dsutils.py
@@ -145,7 +145,6 @@ def encode(
         The encoded dataset as :class:`bytes` (if successful) or ``None`` if
         the encoding failed.
     """
-    # pylint: disable=broad-except
     fp = DicomBytesIO()
     fp.is_implicit_VR = is_implicit_vr
     fp.is_little_endian = is_little_endian

--- a/pynetdicom/events.py
+++ b/pynetdicom/events.py
@@ -98,7 +98,6 @@ class NotificationEvent(NamedTuple):
         return self.name
 
 
-# pylint: disable=line-too-long
 EVT_ABORTED = NotificationEvent("EVT_ABORTED", "Association aborted")
 EVT_ACCEPTED = NotificationEvent("EVT_ACCEPTED", "Association request accepted")  # noqa
 EVT_ACSE_RECV = NotificationEvent(
@@ -189,7 +188,6 @@ EVT_N_EVENT_REPORT = InterventionEvent(
 )  # noqa
 EVT_N_GET = InterventionEvent("EVT_N_GET", "N-GET request received")
 EVT_N_SET = InterventionEvent("EVT_N_SET", "N-SET request received")
-# pylint: enable=line-too-long
 
 _INTERVENTION_EVENTS = [
     ii[1]

--- a/pynetdicom/fsm.py
+++ b/pynetdicom/fsm.py
@@ -34,7 +34,6 @@ class InvalidEventError(Exception):
     pass
 
 
-# pylint: disable=invalid-name
 class StateMachine:
     """Implementation of the DICOM Upper Layer State Machine.
 
@@ -1036,7 +1035,6 @@ def AA_8(dul: "DULServiceProvider") -> str:
 
 # Finite State Machine
 # Machine State Definitions, PS3.8 Tables 9-1, 9-2, 9-3, 9-4, 9-5
-# pylint: disable=line-too-long
 STATES = {
     # No association
     "Sta1": "Idle",

--- a/pynetdicom/pdu.py
+++ b/pynetdicom/pdu.py
@@ -134,7 +134,6 @@ class PDU:
         if other is self:
             return True
 
-        # pylint: disable=protected-access
         if isinstance(other, self.__class__):
             self_dict = {
                 enc[0]: getattr(self, enc[0]) for enc in self._encoders if enc[0]

--- a/pynetdicom/pdu_items.py
+++ b/pynetdicom/pdu_items.py
@@ -2267,7 +2267,6 @@ class SCP_SCU_RoleSelectionSubItem(PDUItem):
     @scu_role.setter
     def scu_role(self, value: int | None) -> None:
         """Set the *SCU Role* field value."""
-        # pylint: disable=attribute-defined-outside-init
         if value not in [0, 1, None]:
             raise ValueError("SCU Role parameter value must be 0 or 1")
         else:
@@ -2286,7 +2285,6 @@ class SCP_SCU_RoleSelectionSubItem(PDUItem):
     @scp_role.setter
     def scp_role(self, value: int | None) -> None:
         """Set the *SCP Role* field value."""
-        # pylint: disable=attribute-defined-outside-init
         if value not in [0, 1, None]:
             raise ValueError("SCP Role parameter value must be 0 or 1")
         else:
@@ -2809,7 +2807,6 @@ class SOPClassCommonExtendedNegotiationSubItem(PDUItem):
         value_list : list of pydicom.uid.UID
             A list of UIDs.
         """
-        # pylint: disable=attribute-defined-outside-init
         self._related_general_sop_class_identification = []
 
         for value in value_list:

--- a/pynetdicom/pdu_primitives.py
+++ b/pynetdicom/pdu_primitives.py
@@ -135,8 +135,6 @@ class A_ASSOCIATE:
       :dcm:`Section 7.1.1<part08/chapter_7.html#sect_7.1.1>`
     """
 
-    # pylint: disable=too-many-instance-attributes
-
     def __init__(self) -> None:
         self._application_context_name: UID | None = None
         self._calling_ae_title: str = "DEFAULT"
@@ -220,7 +218,6 @@ class A_ASSOCIATE:
     @called_presentation_address.setter
     def called_presentation_address(self, value: "AddressInformation | None") -> None:
         """Set the Called Presentation Address parameter."""
-        # pylint: disable=attribute-defined-outside-init
         from pynetdicom.transport import AddressInformation
 
         if value is None or isinstance(value, AddressInformation):
@@ -280,7 +277,6 @@ class A_ASSOCIATE:
         """
         from pynetdicom.transport import AddressInformation
 
-        # pylint: disable=attribute-defined-outside-init
         if value is None or isinstance(value, AddressInformation):
             self._calling_presentation_address = value
             return
@@ -324,7 +320,6 @@ class A_ASSOCIATE:
     def diagnostic(self, value: int | None) -> None:
         """
         Set the A-ASSOCIATE Service primitive's Diagnostic parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if value is None:
             pass
         elif value not in [1, 2, 3, 7]:
@@ -442,7 +437,6 @@ class A_ASSOCIATE:
         """Set the A-ASSOCIATE Service primitive's Presentation Context
         Definition List parameter.
         """
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value_list, list):
             valid_items = []
             for item in value_list:
@@ -482,7 +476,6 @@ class A_ASSOCIATE:
         self, value_list: list[PresentationContext]
     ) -> None:
         """Set the Presentation Context Definition Results List parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value_list, list):
             valid_items = []
             for item in value_list:
@@ -584,7 +577,6 @@ class A_ASSOCIATE:
     @result.setter
     def result(self, value: int | None) -> None:
         """Set the A-ASSOCIATE Service primitive's Result parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if value is None:
             pass
         elif value not in [0, 1, 2]:
@@ -615,7 +607,6 @@ class A_ASSOCIATE:
     @result_source.setter
     def result_source(self, value: int | None) -> None:
         """Set the A-ASSOCIATE Service primitive's Result Source parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if value is None:
             pass
         elif value not in [1, 2, 3]:
@@ -669,7 +660,6 @@ class A_ASSOCIATE:
     @user_information.setter
     def user_information(self, value_list: _UserInformationPrimitiveType) -> None:
         """Set the A-ASSOCIATE primitive's User Information parameter."""
-        # pylint: disable=attribute-defined-outside-init
         valid_usr_info_items = []
 
         if isinstance(value_list, list):
@@ -748,7 +738,6 @@ class A_RELEASE:
     @result.setter
     def result(self, value: str | None) -> None:
         """Set the Result parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if value is not None and value != "affirmative":
             LOGGER.error("A_RELEASE.result must be None or 'affirmative'")
             raise ValueError("A_RELEASE.result must be None or 'affirmative'")
@@ -920,7 +909,6 @@ class P_DATA:
     @presentation_data_value_list.setter
     def presentation_data_value_list(self, value_list: list[tuple[int, bytes]]) -> None:
         """Set the Presentation Data Value List."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value_list, list):
             for pdv in value_list:
                 if isinstance(pdv, list):
@@ -1044,7 +1032,6 @@ class MaximumLengthNotification(ServiceParameter):
     @maximum_length_received.setter
     def maximum_length_received(self, val: int) -> None:
         """User defined Maximum Length to be used during an Association."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(val, int):
             if val < 0:
                 LOGGER.error("Maximum Length Received must be greater than 0")
@@ -1307,7 +1294,6 @@ class AsynchronousOperationsWindowNegotiation(ServiceParameter):
     @maximum_number_operations_invoked.setter
     def maximum_number_operations_invoked(self, value: int) -> None:
         """Sets the Maximum Number Operations Invoked parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, int):
             pass
         else:
@@ -1340,7 +1326,6 @@ class AsynchronousOperationsWindowNegotiation(ServiceParameter):
     @maximum_number_operations_performed.setter
     def maximum_number_operations_performed(self, value: int) -> None:
         """Sets the Maximum Number Operations Performed parameter"""
-        # pylint: disable=attribute-defined-outside-init
         if not isinstance(value, int):
             LOGGER.error("Maximum Number Operations Performed must be an int")
             raise TypeError("Maximum Number Operations Performed must be an int")
@@ -1453,7 +1438,6 @@ class SCP_SCU_RoleSelectionNegotiation(ServiceParameter):
     @scp_role.setter
     def scp_role(self, value: bool | None) -> None:
         """Sets the SCP Role parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bool) or value is None:
             pass
         else:
@@ -1481,7 +1465,6 @@ class SCP_SCU_RoleSelectionNegotiation(ServiceParameter):
     @scu_role.setter
     def scu_role(self, value: bool | None) -> None:
         """Sets the SCU Role parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bool) or value is None:
             pass
         else:
@@ -1600,7 +1583,6 @@ class SOPClassExtendedNegotiation(ServiceParameter):
     @service_class_application_information.setter
     def service_class_application_information(self, value: bytes | None) -> None:
         """Sets the Service Class Application Information parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bytes) or value is None:
             pass
         else:
@@ -1720,7 +1702,6 @@ class SOPClassCommonExtendedNegotiation(ServiceParameter):
         self, uid_list: list[str | bytes | UID]
     ) -> None:
         """Sets the Service Class Application Information parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(uid_list, list):
             # Test that all the items in the list are UID compatible and
             #   convert them to pydicom.uid.UID if required
@@ -1926,7 +1907,6 @@ class UserIdentityNegotiation(ServiceParameter):
     @positive_response_requested.setter
     def positive_response_requested(self, value: bool) -> None:
         """Sets the Positive Response Requested parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bool):
             pass
         else:
@@ -1955,7 +1935,6 @@ class UserIdentityNegotiation(ServiceParameter):
     @primary_field.setter
     def primary_field(self, value: bytes | None) -> None:
         """Sets the Primary Field parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bytes):
             pass
         elif value is None:
@@ -1988,7 +1967,6 @@ class UserIdentityNegotiation(ServiceParameter):
     @secondary_field.setter
     def secondary_field(self, value: bytes | None) -> None:
         """Sets the Secondary Field parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bytes) or value is None:
             pass
         else:
@@ -2029,7 +2007,6 @@ class UserIdentityNegotiation(ServiceParameter):
     @server_response.setter
     def server_response(self, value: bytes | None) -> None:
         """Sets the Server Response parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, bytes):
             pass
         elif value is None:
@@ -2081,7 +2058,6 @@ class UserIdentityNegotiation(ServiceParameter):
     @user_identity_type.setter
     def user_identity_type(self, value: int | None) -> None:
         """Sets the User Identity Type parameter."""
-        # pylint: disable=attribute-defined-outside-init
         if isinstance(value, int):
             if value not in [1, 2, 3, 4, 5]:
                 LOGGER.error(

--- a/pynetdicom/presentation.py
+++ b/pynetdicom/presentation.py
@@ -970,7 +970,6 @@ def build_role(
 
 
 # Service specific pre-generated Presentation Contexts
-# pylint: disable=line-too-long,invalid-name
 ApplicationEventLoggingPresentationContexts = [
     build_context(uid) for uid in sorted(_APPLICATION_EVENT_CLASSES.values())
 ]

--- a/pynetdicom/sop_class.py
+++ b/pynetdicom/sop_class.py
@@ -178,7 +178,6 @@ _SERVICE_CLASSES = {
 }
 
 # Generate the various SOP classes
-# pylint: disable=line-too-long
 _APPLICATION_EVENT_CLASSES = {
     "ProceduralEventLogging": "1.2.840.10008.1.40",
     "SubstanceAdministrationLogging": "1.2.840.10008.1.42",
@@ -509,7 +508,6 @@ _SERVICE_TO_UID_GROUP = {
 }
 
 
-# pylint: enable=line-too-long
 _generate_sop_classes(_APPLICATION_EVENT_CLASSES)
 _generate_sop_classes(_BASIC_WORKLIST_CLASSES)
 _generate_sop_classes(_COLOR_PALETTE_CLASSES)

--- a/pynetdicom/status.py
+++ b/pynetdicom/status.py
@@ -569,7 +569,6 @@ def code_to_category(code: int) -> str:
     """Return a *Status* category as :class:`str` or ``'Unknown'`` if not
     recognised.
     """
-    # pylint: disable=too-many-return-statements
     if isinstance(code, int) and code >= 0:
         if code == 0x0000:
             return STATUS_SUCCESS

--- a/pynetdicom/transport.py
+++ b/pynetdicom/transport.py
@@ -1081,7 +1081,6 @@ class ThreadedAssociationServer(ThreadingMixIn, AssociationServer):
         client_address: tuple[str, int] | str,
     ) -> None:
         """Process a connection request."""
-        # pylint: disable=broad-except
         try:
             self.finish_request(request, client_address)
         except Exception:


### PR DESCRIPTION
As far as i can see pylint is not used any more, this project uses ruff.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Type annotations updated and passing with mypy
- [ ] Apps updated and tested (if relevant)
