### PR TITLE
MyPy `show_error_codes` deprecated

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ exclude = [
     "pynetdicom/benchmarks",
 ]
 files = "pynetdicom/"
-show_error_codes = true
 warn_redundant_casts = true
 warn_unused_ignores = true
 warn_return_any = true


### PR DESCRIPTION
It is now the default, since MyPy v0.990.

<!-- Please use Github's 'Draft Pull Request' for PRs that are in-progress -->
#### Reference issue
The issue describing the bug or feature that this PR addresses.

#### Tasks
- [ ] Unit tests added that reproduce issue or prove feature is working
- [ ] Fix or feature added
- [ ] Documentation and examples updated (if relevant)
- [ ] Unit tests passing and coverage at 100% after adding fix/feature
- [ ] Type annotations updated and passing with mypy
- [ ] Apps updated and tested (if relevant)
