### PR TITLE
[MRG] Document that the acceptor's transfer syntax order decides negotiation

### DIFF
--- a/docs/user/presentation_negotiation.rst
+++ b/docs/user/presentation_negotiation.rst
@@ -81,3 +81,23 @@ While the *acceptor* supports:
         =Explicit VR Big Endian
 
 Then the accepted transfer syntax will be *Explicit VR Little Endian*.
+
+Note that this is the *acceptor's* order of preference, not the *requestor's*.
+:dcm:`PS3.7 Section D.3.2<part07/sect_D.3.2.html>` requires only that exactly
+one of the proposed transfer syntaxes be accepted and leaves the choice to the
+*acceptor*, so a *requestor* that lists a compressed syntax first has no way to
+insist on it. If you are acting as the *acceptor* and want a particular syntax
+to win whenever a *requestor* offers it -- keeping compressed data in its
+original encoding, for example -- then list it first:
+
+  .. code-block:: python
+
+      from pynetdicom import AE
+      from pynetdicom.sop_class import DigitalMammographyXRayImageStorageForPresentation
+
+      ae = AE()
+      # JPEG-LS Lossless is accepted whenever the requestor proposes it
+      ae.add_supported_context(
+          DigitalMammographyXRayImageStorageForPresentation,
+          ["1.2.840.10008.1.2.4.80", "1.2.840.10008.1.2"],
+      )

--- a/pynetdicom/ae.py
+++ b/pynetdicom/ae.py
@@ -286,13 +286,20 @@ class ApplicationEntity:
         a supported context or one or more of its transfer syntaxes see the
         :meth:`remove_supported_context` method.
 
+        The order of `transfer_syntax` matters. When acting as the association
+        *acceptor* the first supported transfer syntax that the *requestor*
+        also proposed is the one that gets accepted, so the syntaxes should be
+        listed in order of preference. The *requestor's* own ordering is not
+        taken into account. See :doc:`presentation context negotiation
+        </user/presentation_negotiation>` for a worked example.
+
         Parameters
         ----------
         abstract_syntax : str, pydicom.uid.UID
             The abstract syntax of the presentation context to be supported.
         transfer_syntax :  str/pydicom.uid.UID or list of str/pydicom.uid.UID
-            The transfer syntax(es) to support (default:
-            :attr:`~pynetdicom._globals.DEFAULT_TRANSFER_SYNTAXES`).
+            The transfer syntax(es) to support, in order of preference
+            (default: :attr:`~pynetdicom._globals.DEFAULT_TRANSFER_SYNTAXES`).
         scu_role : bool or None, optional
             If the association requestor includes an
             :doc:`SCP/SCU Role Selection Negotiation</user/presentation_role_selection>`

--- a/pynetdicom/presentation.py
+++ b/pynetdicom/presentation.py
@@ -601,6 +601,13 @@ def negotiate_as_acceptor(
 ) -> CXNegotiationReturn:
     """Process the Presentation Contexts as an Association *Acceptor*.
 
+    For each context proposed by the *Requestor* whose abstract syntax is
+    supported, the accepted transfer syntax is the first entry in the
+    *Acceptor's* ``transfer_syntax`` that the *Requestor* also proposed. The
+    *Requestor's* ordering is not used: :dcm:`PS3.7 Section D.3.2
+    <part07/sect_D.3.2.html>` requires only that exactly one of the proposed
+    transfer syntaxes be accepted, and leaves the choice to the *Acceptor*.
+
     Parameters
     ----------
     rq_contexts : list of PresentationContext


### PR DESCRIPTION
Follow-up to #1085, which read the acceptor-preference behaviour as a bug.

The rule is already stated in the "Implementation Note" on the presentation context negotiation page, but it isn't mentioned at either API surface where an SCP is actually configured, so a requestor's preferred transfer syntax losing to the acceptor's reads as a defect rather than as intended behaviour.

- `AE.add_supported_context`: note that `transfer_syntax` is given in order of preference, that the first entry the *requestor* also proposed is the one accepted, and that the *requestor's* ordering is not taken into account.
- `negotiate_as_acceptor`: state the same selection rule, citing PS3.7 Section D.3.2, which requires only that exactly one of the proposed transfer syntaxes be accepted and leaves the choice to the acceptor.
- Negotiation page: add the consequence (a requestor cannot insist on a compressed syntax) and the remedy (list it first on the acceptor), with a runnable example.

Documentation only, no behaviour change. The example was run against 3.0.4 and accepts JPEG-LS Lossless as written.
