### PR TITLE
Point the ruff-check pre-commit hook at pynetdicom instead of src

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.15.5
     hooks:
       - id: ruff-check
-        files: src
+        files: pynetdicom
         args: ["--fix", "--show-fixes"]
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.3.0


### PR DESCRIPTION
Fixes #1090. Points the `ruff-check` pre-commit hook at `pynetdicom` instead of the nonexistent `src`.
